### PR TITLE
Fix resources retrieval with a full URL as ID

### DIFF
--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -39,18 +39,18 @@ module EnvelopeHelpers
   end
 
   def find_envelope
-    @envelope = Envelope.where('processed_resource @> ?',
+    envelopes = Envelope.where('processed_resource @> ?',
                                { '@id' => params[:id] }.to_json)
 
     unless params[:envelope_community].blank?
-      @envelope = @envelope.in_community(community)
+      envelopes = envelopes.in_community(community)
     end
 
-    if @envelope.blank?
+    if envelopes.blank?
       err = ['No matching resource found']
       json_error! err, nil, :not_found
     end
 
-    @envelope = @envelope.first
+    @envelope = envelopes.first
   end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -40,7 +40,7 @@ module EnvelopeHelpers
 
   def find_envelope
     envelopes = Envelope.where('processed_resource @> ?',
-                               { '@id' => combine_id_format }.to_json)
+                               { '@id' => params[:id] }.to_json)
 
     unless params[:envelope_community].blank?
       # TODO: else default community (#36)
@@ -53,19 +53,5 @@ module EnvelopeHelpers
     end
 
     @envelope = envelopes.first
-  end
-
-  def combine_id_format
-    if params[:id] && params[:format] && params[:id] =~ /:/
-      # resource IDs like
-      # http://credentialengine.org/resource/urn:ctid:123e4567-e89b-...
-      # if sent URL encoded
-      # http%3A%2F%2Fcredentialengine.org%2Fresource%2Furn%3Actid%3A123...
-      # => params[:id] everything before the .
-      # => params[:format] everything after the .
-      "#{params[:id]}.#{params[:format]}"
-    else
-      params[:id]
-    end
   end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -40,9 +40,10 @@ module EnvelopeHelpers
 
   def find_envelope
     envelopes = Envelope.where('processed_resource @> ?',
-                               { '@id' => params[:id] }.to_json)
+                               { '@id' => combine_id_format }.to_json)
 
     unless params[:envelope_community].blank?
+      # TODO: else default community (#36)
       envelopes = envelopes.in_community(community)
     end
 
@@ -52,5 +53,19 @@ module EnvelopeHelpers
     end
 
     @envelope = envelopes.first
+  end
+
+  def combine_id_format
+    if params[:id] && params[:format] && params[:id] =~ /:/
+      # resource IDs like
+      # http://credentialengine.org/resource/urn:ctid:123e4567-e89b-...
+      # if sent URL encoded
+      # http%3A%2F%2Fcredentialengine.org%2Fresource%2Furn%3Actid%3A123...
+      # => params[:id] everything before the .
+      # => params[:format] everything after the .
+      "#{params[:id]}.#{params[:format]}"
+    else
+      params[:id]
+    end
   end
 end

--- a/app/api/v1/resources_api.rb
+++ b/app/api/v1/resources_api.rb
@@ -49,7 +49,7 @@ module API
             after_validation do
               find_envelope
             end
-            get ':id' do
+            get ':id', requirements: { id: /(.*)/i } do
               present @envelope.processed_resource
             end
 
@@ -61,7 +61,7 @@ module API
             after_validation do
               find_envelope
             end
-            put ':id' do
+            put ':id', requirements: { id: /(.*)/i } do
               sanitized_params = params.dup
               sanitized_params.delete(:id)
               envelope, errors = EnvelopeBuilder.new(
@@ -85,7 +85,7 @@ module API
               find_envelope
               params[:envelope_id] = @envelope.envelope_id
             end
-            delete ':id' do
+            delete ':id', requirements: { id: /(.*)/i } do
               validator = JSONSchemaValidator.new(params, :delete_envelope)
               if validator.invalid?
                 json_error! validator.error_messages, :delete_envelope

--- a/spec/api/v1/resources_spec.rb
+++ b/spec/api/v1/resources_spec.rb
@@ -37,6 +37,22 @@ describe API::V1::Resources do
 
       it { expect_status(:not_found) }
     end
+
+    context 'full URL as ID' do
+      let!(:id) { 'http://example.com/resources/ctid:id-123412312313' }
+      before do
+        res = resource.merge('@id' => id, 'ceterms:ctid' => 'ctid:id-312313')
+        create(:envelope, :from_cer, :with_cer_credential,
+               resource: jwt_encode(res), envelope_community: ec)
+        get "/api/resources/#{CGI.escape(id)}"
+      end
+
+      it { expect_status(:ok) }
+
+      it 'retrieves the desired resource' do
+        expect_json('@id': id)
+      end
+    end
   end
 
   context 'PUT /api/resources/:id' do


### PR DESCRIPTION
The retrieval of a resource with a full URL as the ID was broken, as grape interpreted a dot (`.`) in the URL as a format (such as `.html`).

The fix is not exactly pretty but the whole area is subject to change with the default community (#36) and `@id` prefix (#42) still unresolved.