### PR TITLE
Default community

### DIFF
--- a/app/api/helpers/shared_helpers.rb
+++ b/app/api/helpers/shared_helpers.rb
@@ -11,6 +11,15 @@ module SharedHelpers
              values: -> { EnvelopeCommunity.pluck(:name) }
   end
 
+  # duplicate of `:envelope_community` with a different name
+  # in order to identify a clash between the url parameter and the body
+  # parameter.
+  # This should be consolidated e.g. by changing the parameter for the
+  # /envelopes endpoint
+  params :community_name do
+    optional :community_name, values: -> { EnvelopeCommunity.pluck(:name) }
+  end
+
   params :pagination do
     optional :page, type: Integer, default: 1, desc: 'Page number'
     optional :per_page, type: Integer, default: 10, desc: 'Items per page'

--- a/app/api/v1/base.rb
+++ b/app/api/v1/base.rb
@@ -30,6 +30,9 @@ module API
 
       route_param :envelope_community do
         mount API::V1::Envelopes
+      end
+
+      route_param :community_name do
         mount API::V1::CommunityResources
       end
     end

--- a/app/api/v1/community_helpers.rb
+++ b/app/api/v1/community_helpers.rb
@@ -1,0 +1,49 @@
+# EnvelopeCommunity specific helpers
+module CommunityHelpers
+  extend Grape::API::Helpers
+
+  def select_community
+    given_community || default_community
+  end
+
+  def default_community
+    @default ||= EnvelopeCommunity.host_mapped(@env['HTTP_HOST']) ||
+                 EnvelopeCommunity.default.name
+  end
+
+  def community_error(msg)
+    json_error! [msg], nil, :unprocessable_entity
+  end
+
+  def normalized_community_names
+    [
+      params[:community_name].try(:underscore),
+      params[:envelope_community].try(:underscore)
+    ]
+  end
+
+  def given_community
+    url_name, env_name = normalized_community_names
+    matching_url_env_community(url_name, env_name) ||
+      valid_env_community(env_name)
+  end
+
+  # Check if the community in the envelope and URL are identical
+  def matching_url_env_community(url_name, env_name)
+    if env_name && url_name && env_name != url_name
+      community_error(':envelope_community in URL and envelope don\'t match.')
+    end
+
+    url_name
+  end
+
+  # Check if the community in the envelope is the same as the default
+  def valid_env_community(env_name)
+    if env_name && env_name != default_community
+      community_error(
+        ':envelope_community in envelope does not match the default ' \
+        "community (#{default_community})."
+      )
+    end
+  end
+end

--- a/app/api/v1/community_resources.rb
+++ b/app/api/v1/community_resources.rb
@@ -3,7 +3,7 @@ module API
     # Implements all the endpoints related to resources
     class CommunityResources < Grape::API
       include API::V1::ResourceAPI
-      params { use :envelope_community }
+      params { use :community_name }
     end
   end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -42,10 +42,7 @@ module EnvelopeHelpers
     envelopes = Envelope.where('processed_resource @> ?',
                                { '@id' => params[:id] }.to_json)
 
-    unless params[:envelope_community].blank?
-      # TODO: else default community (#36)
-      envelopes = envelopes.in_community(community)
-    end
+    envelopes = envelopes.in_community(select_community)
 
     if envelopes.blank?
       err = ['No matching resource found']
@@ -53,5 +50,14 @@ module EnvelopeHelpers
     end
 
     @envelope = envelopes.first
+  end
+
+  def select_community
+    return community unless community.blank?
+
+    # TODO: throw exception if URL parameter `envelope_community` and
+    # body parameter `envelope_community` mismatch
+    EnvelopeCommunity.host_mapped(@env['HTTP_HOST']) ||
+      EnvelopeCommunity.default.name
   end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -51,49 +51,4 @@ module EnvelopeHelpers
 
     @envelope = envelopes.first
   end
-
-  def select_community
-    given_community || default_community
-  end
-
-  def default_community
-    @default ||= EnvelopeCommunity.host_mapped(@env['HTTP_HOST']) ||
-                 EnvelopeCommunity.default.name
-  end
-
-  def community_error(msg)
-    json_error! [msg], nil, :unprocessable_entity
-  end
-
-  def normalized_community_names
-    [
-      params[:community_name].try(:underscore),
-      params[:envelope_community].try(:underscore)
-    ]
-  end
-
-  def given_community
-    url_name, env_name = normalized_community_names
-    matching_url_env_community(url_name, env_name) ||
-      valid_env_community(env_name)
-  end
-
-  # Check if the community in the envelope and URL are identical
-  def matching_url_env_community(url_name, env_name)
-    if env_name && url_name && env_name != url_name
-      community_error(':envelope_community in URL and envelope don\'t match.')
-    end
-
-    url_name
-  end
-
-  # Check if the community in the envelope is the same as the default
-  def valid_env_community(env_name)
-    if env_name && env_name != default_community
-      community_error(
-        ':envelope_community in envelope does not match the default ' \
-        "community (#{default_community})."
-      )
-    end
-  end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -53,11 +53,47 @@ module EnvelopeHelpers
   end
 
   def select_community
-    return community unless community.blank?
+    given_community || default_community
+  end
 
-    # TODO: throw exception if URL parameter `envelope_community` and
-    # body parameter `envelope_community` mismatch
-    EnvelopeCommunity.host_mapped(@env['HTTP_HOST']) ||
-      EnvelopeCommunity.default.name
+  def default_community
+    @default ||= EnvelopeCommunity.host_mapped(@env['HTTP_HOST']) ||
+                 EnvelopeCommunity.default.name
+  end
+
+  def community_error(msg)
+    json_error! [msg], nil, :unprocessable_entity
+  end
+
+  def normalized_community_names
+    [
+      params[:community_name].try(:underscore),
+      params[:envelope_community].try(:underscore)
+    ]
+  end
+
+  def given_community
+    url_name, env_name = normalized_community_names
+    matching_url_env_community(url_name, env_name) ||
+      valid_env_community(env_name)
+  end
+
+  # Check if the community in the envelope and URL are identical
+  def matching_url_env_community(url_name, env_name)
+    if env_name && url_name && env_name != url_name
+      community_error(':envelope_community in URL and envelope don\'t match.')
+    end
+
+    url_name
+  end
+
+  # Check if the community in the envelope is the same as the default
+  def valid_env_community(env_name)
+    if env_name && env_name != default_community
+      community_error(
+        ':envelope_community in envelope does not match the default ' \
+        "community (#{default_community})."
+      )
+    end
   end
 end

--- a/app/api/v1/resources_api.rb
+++ b/app/api/v1/resources_api.rb
@@ -26,6 +26,7 @@ module API
               use :skip_validation
             end
             post do
+              params[:envelope_community] = select_community
               envelope, errors = EnvelopeBuilder.new(
                 params,
                 update_if_exists: update_if_exists?,
@@ -35,7 +36,6 @@ module API
               if errors
                 json_error! errors, [:envelope,
                                      envelope.try(:resource_schema_name)]
-
               else
                 present envelope, with: API::Entities::Envelope
                 update_if_exists? ? status(:ok) : status(:created)

--- a/app/api/v1/resources_api.rb
+++ b/app/api/v1/resources_api.rb
@@ -13,8 +13,6 @@ module API
           helpers SharedHelpers
           helpers EnvelopeHelpers
 
-          before_validation { normalize_envelope_community }
-
           resource :resources do
             desc 'Publishes a new envelope',
                  http_codes: [
@@ -62,6 +60,7 @@ module API
               find_envelope
             end
             put ':id', requirements: { id: /(.*)/i } do
+              params[:envelope_community] = select_community
               sanitized_params = params.dup
               sanitized_params.delete(:id)
               envelope, errors = EnvelopeBuilder.new(

--- a/app/api/v1/resources_api.rb
+++ b/app/api/v1/resources_api.rb
@@ -1,3 +1,14 @@
+require 'envelope'
+require 'delete_token'
+require 'batch_delete_envelopes'
+require 'envelope_builder'
+require 'entities/envelope'
+require 'helpers/shared_helpers'
+require 'v1/community_helpers'
+require 'v1/envelope_helpers'
+require 'v1/single_envelope'
+require 'v1/versions'
+
 module API
   module V1
     # Implements all the endpoints related to resources
@@ -11,6 +22,7 @@ module API
           include API::V1::Defaults
 
           helpers SharedHelpers
+          helpers CommunityHelpers
           helpers EnvelopeHelpers
 
           resource :resources do

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -50,6 +50,7 @@ class Envelope < ActiveRecord::Base
   scope :deleted, -> { unscoped.where.not(deleted_at: nil) }
   scope :ordered_by_date, -> { order(created_at: :desc) }
   scope :in_community, (lambda do |community|
+    return unless community
     joins(:envelope_community).where(envelope_communities: { name: community })
   end)
 

--- a/app/models/envelope_community.rb
+++ b/app/models/envelope_community.rb
@@ -10,6 +10,10 @@ class EnvelopeCommunity < ActiveRecord::Base
     where(default: true).first
   end
 
+  def self.host_mapped(host)
+    host_mappings[host]
+  end
+
   def config(type = nil)
     @config ||= JSON.parse File.read(config_path)
     type.present? ? @config[type] : @config
@@ -43,6 +47,18 @@ class EnvelopeCommunity < ActiveRecord::Base
     else
       get_resource_type_from_values_map(cfg, envelope)
     end
+  end
+
+  private_class_method
+
+  def self.host_mappings
+    JSON.parse(File.read(File.join(MR.config_path,
+                                   '/envelope_communities.json')))
+  rescue Errno::ENOENT
+    {}
+  rescue JSON::ParserError
+    MR.logger.error('envelope_communities.json is not valid JSON')
+    {}
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,10 @@ module MetadataRegistry
     'tmp/dumps'
   end
 
+  def self.config_path
+    File.expand_path('../../config/', __FILE__)
+  end
+
   def self.fixtures_path
     @schemas_path ||= File.expand_path('../../fixtures/', __FILE__)
   end

--- a/config/envelope_communities.json
+++ b/config/envelope_communities.json
@@ -1,0 +1,3 @@
+{
+    "lr-staging.learningtapestry.com": "ce_registry"
+}

--- a/config/envelope_communities.json
+++ b/config/envelope_communities.json
@@ -1,3 +1,4 @@
 {
-    "lr-staging.learningtapestry.com": "ce_registry"
+    "lr-staging.learningtapestry.com": "ce_registry",
+    "example.org": "ce_registry"
 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 EnvelopeCommunity.create([{ name: 'learning_registry',
-                            backup_item: 'learning-registry-test',
-                            default: true },
+                            backup_item: 'learning-registry-test' },
                           { name: 'ce_registry',
-                            backup_item: 'ce-registry-test' }])
+                            backup_item: 'ce-registry-test',
+                            default: true }])

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -162,7 +162,7 @@ Please note that you should replace the contents of resouce and resource_public_
 Let's store this JSON snippet in a file called `envelope.json`, so we can
 reference it in the next step.
 
-### 4. Call the `publish envelope` endpoint
+### 4. Call the `publish resource` endpoint
 The last step involves calling the actual endpoint with our request data so that
 the envelope is finally published on our development Metadata Registry node.
 
@@ -173,18 +173,18 @@ Since we always work in a community context, our endpoints follow the pattern:
 ```
 
 So for publishing an envelope for the \"ce-registry\" community,
-you would use `/api/ce-registry/envelopes`.
+you would use `/api/ce-registry/resources`.
 
 Since this is a REST API, we can use typical tools like cURL or HTTPie.
 
 #### Using HTTPie
 ```shell
-http POST :9292/api/learning-registry/envelopes < envelope.json
+http POST :9292/api/learning-registry/resources < envelope.json
 ```
 
 #### Using cURL
 ```shell
-curl -X POST http://localhost:9292/api/learning-registry/envelopes -d @envelope.json \
+curl -X POST http://localhost:9292/api/learning-registry/resources -d @envelope.json \
 --header "Content-Type: application/json"
 ```
 

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -175,6 +175,13 @@ Since we always work in a community context, our endpoints follow the pattern:
 So for publishing an envelope for the \"ce-registry\" community,
 you would use `/api/ce-registry/resources`.
 
+For convenience's sake a default community can be configured both globally and
+per host. This allows us to drop the community part from the URL.
+
+```
+/api/resources
+```
+
 Since this is a REST API, we can use typical tools like cURL or HTTPie.
 
 #### Using HTTPie

--- a/docs/02_ce-registry_walkthrough.md
+++ b/docs/02_ce-registry_walkthrough.md
@@ -303,6 +303,11 @@ For example:
 
 These parameters also work with search requests. [Read more about searching envelopes](/docs/07_search.md).
 
+## 11 - Configuring the default community
+
+A default community can be configured both globally ([See `db/seeds.rb`](../blob/master/db/seeds.rb))
+as well as per server host ([See `config/envelope_communities.json`](../blob/a7e26d4542e0861e1b62fcdcd510819be510e378/config/envelope_communities.json)).
+
 -----
 
 For more info check our swagger docs and the json-schemas.

--- a/spec/models/envelope_community_spec.rb
+++ b/spec/models/envelope_community_spec.rb
@@ -35,6 +35,15 @@ describe EnvelopeCommunity, type: :model do
     end
   end
 
+  describe '.host_mapped' do
+    [
+      ['lr-staging.learningtapestry.com', 'ce_registry'],
+      ['not-mapped.example.com', nil]
+    ].each do |host, name|
+      it { expect(EnvelopeCommunity.host_mapped(host)).to eq(name) }
+    end
+  end
+
   describe 'config' do
     it '#config provide the community config' do
       community = EnvelopeCommunity.new name: 'ce_registry'

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -88,6 +88,19 @@ describe Envelope, type: :model do
     end
   end
 
+  describe '.in_community' do
+    let!(:envelope) { create(:envelope) }
+    let!(:name)     { envelope.envelope_community.name }
+
+    it 'find envelopes with community' do
+      expect(Envelope.in_community(name).find(envelope.id)).to eq(envelope)
+    end
+
+    it 'find envelopes with `nil` community' do
+      expect(Envelope.in_community(nil).find(envelope.id)).to eq(envelope)
+    end
+  end
+
   describe 'resource_schema_name' do
     context 'community without type' do
       let(:envelope) { create(:envelope) }


### PR DESCRIPTION
* The overall default community is (currently) set in the database (see example in [seeds.rb](../blob/ff498c3d0ffb64d633b0bc22e5166c893fa17234/db/seeds.rb#L3)).
* Host specific default communities can be configured in [`config/envelope_communities.json`](../blob/a7e26d4542e0861e1b62fcdcd510819be510e378/config/envelope_communities.json)

Implements #36 