### PR TITLE
Id prefix

### DIFF
--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -39,16 +39,12 @@ module EnvelopeHelpers
   end
 
   def find_envelope
-    envelopes = Envelope.where('processed_resource @> ?',
-                               { '@id' => params[:id] }.to_json)
+    @envelope = Envelope.in_community(select_community)
+                        .by_resource_id(params[:id])
 
-    envelopes = envelopes.in_community(select_community)
-
-    if envelopes.blank?
+    if @envelope.blank?
       err = ['No matching resource found']
       json_error! err, nil, :not_found
     end
-
-    @envelope = envelopes.first
   end
 end

--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -39,8 +39,7 @@ module EnvelopeHelpers
   end
 
   def find_envelope
-    @envelope = Envelope.in_community(select_community)
-                        .by_resource_id(params[:id])
+    @envelope = Envelope.community_resource(select_community, params[:id])
 
     if @envelope.blank?
       err = ['No matching resource found']

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -54,6 +54,10 @@ class Envelope < ActiveRecord::Base
     joins(:envelope_community).where(envelope_communities: { name: community })
   end)
 
+  def self.by_resource_id(id)
+    find_by('processed_resource @> ?', { '@id' => id }.to_json)
+  end
+
   def self.select_scope(include_deleted = nil)
     if include_deleted == 'true'
       unscoped.all

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -58,6 +58,13 @@ class Envelope < ActiveRecord::Base
     find_by('processed_resource @> ?', { '@id' => id }.to_json)
   end
 
+  def self.community_resource(community_name, id)
+    prefix = EnvelopeCommunity.find_by(name: community_name).try(:id_prefix)
+
+    in_community(community_name).by_resource_id("#{prefix}#{id}") ||
+      in_community(community_name).by_resource_id(id)
+  end
+
   def self.select_scope(include_deleted = nil)
     if include_deleted == 'true'
       unscoped.all

--- a/app/models/envelope_community.rb
+++ b/app/models/envelope_community.rb
@@ -25,6 +25,10 @@ class EnvelopeCommunity < ActiveRecord::Base
     config['skip_validation_enabled']
   end
 
+  def id_prefix
+    config['id_prefix']
+  end
+
   # get the resource_type for the envelope from the community config (if exists)
   # Ex:
   #   1) resource_type is a string

--- a/app/models/envelope_community.rb
+++ b/app/models/envelope_community.rb
@@ -52,8 +52,9 @@ class EnvelopeCommunity < ActiveRecord::Base
   private_class_method
 
   def self.host_mappings
-    JSON.parse(File.read(File.join(MR.config_path,
-                                   '/envelope_communities.json')))
+    @host_mappings ||= JSON.parse(
+      File.read(File.join(MR.config_path, '/envelope_communities.json'))
+    )
   rescue Errno::ENOENT
     {}
   rescue JSON::ParserError

--- a/db/migrate/20170412045538_add_index_for_resource_id_on_envelopes.rb
+++ b/db/migrate/20170412045538_add_index_for_resource_id_on_envelopes.rb
@@ -1,0 +1,10 @@
+class AddIndexForResourceIdOnEnvelopes < ActiveRecord::Migration
+  def up
+    execute('CREATE INDEX envelopes_resources_id_idx ON envelopes ' \
+            '((processed_resource->>\'@id\'));')
+  end
+
+  def down
+    execute("DROP INDEX envelopes_resources_id_idx")
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,17 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.6.2
+-- Dumped by pg_dump version 9.6.2
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -44,7 +49,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: administrative_accounts; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: administrative_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE administrative_accounts (
@@ -75,7 +80,7 @@ ALTER SEQUENCE administrative_accounts_id_seq OWNED BY administrative_accounts.i
 
 
 --
--- Name: envelope_communities; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: envelope_communities; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE envelope_communities (
@@ -108,7 +113,7 @@ ALTER SEQUENCE envelope_communities_id_seq OWNED BY envelope_communities.id;
 
 
 --
--- Name: envelope_transactions; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: envelope_transactions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE envelope_transactions (
@@ -140,7 +145,7 @@ ALTER SEQUENCE envelope_transactions_id_seq OWNED BY envelope_transactions.id;
 
 
 --
--- Name: envelopes; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: envelopes; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE envelopes (
@@ -186,7 +191,7 @@ ALTER SEQUENCE envelopes_id_seq OWNED BY envelopes.id;
 
 
 --
--- Name: json_schemas; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: json_schemas; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE json_schemas (
@@ -218,7 +223,7 @@ ALTER SEQUENCE json_schemas_id_seq OWNED BY json_schemas.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -227,7 +232,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE versions (
@@ -262,49 +267,49 @@ ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: administrative_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY administrative_accounts ALTER COLUMN id SET DEFAULT nextval('administrative_accounts_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: envelope_communities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelope_communities ALTER COLUMN id SET DEFAULT nextval('envelope_communities_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: envelope_transactions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelope_transactions ALTER COLUMN id SET DEFAULT nextval('envelope_transactions_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: envelopes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelopes ALTER COLUMN id SET DEFAULT nextval('envelopes_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: json_schemas id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY json_schemas ALTER COLUMN id SET DEFAULT nextval('json_schemas_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
 
 
 --
--- Name: administrative_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: administrative_accounts administrative_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY administrative_accounts
@@ -312,7 +317,7 @@ ALTER TABLE ONLY administrative_accounts
 
 
 --
--- Name: envelope_communities_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: envelope_communities envelope_communities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelope_communities
@@ -320,7 +325,7 @@ ALTER TABLE ONLY envelope_communities
 
 
 --
--- Name: envelope_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: envelope_transactions envelope_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelope_transactions
@@ -328,7 +333,7 @@ ALTER TABLE ONLY envelope_transactions
 
 
 --
--- Name: envelopes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: envelopes envelopes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelopes
@@ -336,7 +341,7 @@ ALTER TABLE ONLY envelopes
 
 
 --
--- Name: json_schemas_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: json_schemas json_schemas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY json_schemas
@@ -344,7 +349,7 @@ ALTER TABLE ONLY json_schemas
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions
@@ -352,98 +357,105 @@ ALTER TABLE ONLY versions
 
 
 --
--- Name: envelopes_fts_trigram_idx; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: envelopes_fts_trigram_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX envelopes_fts_trigram_idx ON envelopes USING gin (fts_trigram gin_trgm_ops);
 
 
 --
--- Name: index_administrative_accounts_on_public_key; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: envelopes_resources_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX envelopes_resources_id_idx ON envelopes USING btree (((processed_resource ->> '@id'::text)));
+
+
+--
+-- Name: index_administrative_accounts_on_public_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_administrative_accounts_on_public_key ON administrative_accounts USING btree (public_key);
 
 
 --
--- Name: index_envelope_communities_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelope_communities_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_envelope_communities_on_name ON envelope_communities USING btree (name);
 
 
 --
--- Name: index_envelopes_on_envelope_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelopes_on_envelope_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_envelopes_on_envelope_id ON envelopes USING btree (envelope_id);
 
 
 --
--- Name: index_envelopes_on_envelope_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelopes_on_envelope_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_envelopes_on_envelope_type ON envelopes USING btree (envelope_type);
 
 
 --
--- Name: index_envelopes_on_envelope_version; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelopes_on_envelope_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_envelopes_on_envelope_version ON envelopes USING btree (envelope_version);
 
 
 --
--- Name: index_envelopes_on_fts_tsearch_tsv; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelopes_on_fts_tsearch_tsv; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_envelopes_on_fts_tsearch_tsv ON envelopes USING gin (fts_tsearch_tsv);
 
 
 --
--- Name: index_envelopes_on_processed_resource; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_envelopes_on_processed_resource; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_envelopes_on_processed_resource ON envelopes USING gin (processed_resource);
 
 
 --
--- Name: index_json_schemas_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_json_schemas_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_json_schemas_on_name ON json_schemas USING btree (name);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
 
 
 --
--- Name: index_versions_on_object; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_versions_on_object; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_versions_on_object ON versions USING gin (object);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
 
 
 --
--- Name: fts_tsvector_update; Type: TRIGGER; Schema: public; Owner: -
+-- Name: envelopes fts_tsvector_update; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER fts_tsvector_update BEFORE INSERT OR UPDATE ON envelopes FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('fts_tsearch_tsv', 'pg_catalog.simple', 'fts_tsearch');
 
 
 --
--- Name: fk_rails_5407a61089; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: envelope_transactions fk_rails_5407a61089; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelope_transactions
@@ -451,7 +463,7 @@ ALTER TABLE ONLY envelope_transactions
 
 
 --
--- Name: fk_rails_fbac8d1e0a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: envelopes fk_rails_fbac8d1e0a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY envelopes
@@ -462,7 +474,7 @@ ALTER TABLE ONLY envelopes
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20160223171632');
 
@@ -491,4 +503,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161101121532');
 INSERT INTO schema_migrations (version) VALUES ('20161108105842');
 
 INSERT INTO schema_migrations (version) VALUES ('20170312011508');
+
+INSERT INTO schema_migrations (version) VALUES ('20170412045538');
 

--- a/docs/98_administrator_notes.md
+++ b/docs/98_administrator_notes.md
@@ -1,0 +1,19 @@
+# Administrator Notes
+
+## Default Community
+
+A global default community is configured in the database ([as per `db/seeds.rb`](../blob/master/db/seeds.rb)),
+however an instance (host) specific default can be configured via [`config/envelope_communities.json`](../blob/a7e26d4542e0861e1b62fcdcd510819be510e378/config/envelope_communities.json)).
+
+## ID Prefix
+
+If the ID of a resource is the full URL (e.g.
+`http://example.com/resources/1234`), the end-user should not have to include
+the host and path parts (`http://example.com/resources/`) of the ID. Within
+a community, the user should be able to request the resource with the id
+(`1234`). The prefix in this example would be `http://example.com/resources/`.
+
+For more information see [Issue #43](https://github.com/CredentialEngine/CredentialRegistry/issues/42).
+
+To configure the prefix, simply state it's value in the community's
+configuration file. See [`fixtures/configs/ce_registry.json`](../blob/971e5e2aa1e3778ddcf813bd31c0ff3258bcfc1c/fixtures/configs/ce_registry.json#L78)) as an example.

--- a/docs/98_administrator_notes.md
+++ b/docs/98_administrator_notes.md
@@ -13,7 +13,7 @@ the host and path parts (`http://example.com/resources/`) of the ID. Within
 a community, the user should be able to request the resource with the id
 (`1234`). The prefix in this example would be `http://example.com/resources/`.
 
-For more information see [Issue #43](https://github.com/CredentialEngine/CredentialRegistry/issues/42).
+For more information see [Issue #42](https://github.com/CredentialEngine/CredentialRegistry/issues/42).
 
 To configure the prefix, simply state it's value in the community's
 configuration file. See [`fixtures/configs/ce_registry.json`](../blob/971e5e2aa1e3778ddcf813bd31c0ff3258bcfc1c/fixtures/configs/ce_registry.json#L78)) as an example.

--- a/fixtures/configs/ce_registry.json
+++ b/fixtures/configs/ce_registry.json
@@ -73,5 +73,7 @@
       "full": ["ceterms:name", "ceterms:description"],
       "partial": ["ceterms:name"]
     }
-  }
+  },
+
+  "id_prefix": "http://credentialengine.org/resources/"
 }

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -17,7 +17,9 @@ FactoryGirl.define do
         rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
       }
     end
-    add_attribute(:'@id') { Envelope.generate_ctid }
+    add_attribute(:'@id') do
+      "http://credentialengine.org/resources/#{Envelope.generate_ctid}"
+    end
     add_attribute(:'ceterms:name') { 'Test Org' }
   end
 
@@ -33,7 +35,9 @@ FactoryGirl.define do
         ceterms: 'http://purl.org/ctdl/terms/'
       }
     end
-    add_attribute(:'@id') { Envelope.generate_ctid }
+    add_attribute(:'@id') do
+      "http://credentialengine.org/resources/#{Envelope.generate_ctid}"
+    end
     add_attribute(:'ceterms:ctid') { send(:'@id') }
     add_attribute(:'ceterms:name') { 'Test Cred' }
     add_attribute(:'ceterms:url') { { '@id': 'http://example.com/test-cred' } }

--- a/spec/models/envelope_community_spec.rb
+++ b/spec/models/envelope_community_spec.rb
@@ -65,4 +65,16 @@ describe EnvelopeCommunity, type: :model do
       )
     end
   end
+
+  context '#id_prefix' do
+    [
+      ['ce_registry', 'http://credentialengine.org/resources/'],
+      ['learning_registry', nil]
+    ].each do |ec, prefix|
+      describe ec do
+        let(:community) { EnvelopeCommunity.new name: ec }
+        it { expect(community.id_prefix).to eq(prefix) }
+      end
+    end
+  end
 end

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -108,6 +108,20 @@ describe Envelope, type: :model do
     end
   end
 
+  describe '.by_resource_id' do
+    let!(:envelope) { create(:envelope, :from_cer, :with_cer_credential) }
+    let!(:id)       { envelope.processed_resource['@id'] }
+
+    it 'find the correct envelope' do
+      expect(Envelope.by_resource_id(id)).to eq(envelope)
+    end
+
+    describe 'doesn\'t find envelopes with invalid ID' do
+      let!(:id) { '9999INVALID' }
+      it { expect(Envelope.by_resource_id(id)).to be_nil }
+    end
+  end
+
   describe 'resource_schema_name' do
     context 'community without type' do
       let(:envelope) { create(:envelope) }

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -91,6 +91,7 @@ describe Envelope, type: :model do
   describe '.in_community' do
     let!(:envelope) { create(:envelope) }
     let!(:name)     { envelope.envelope_community.name }
+    let!(:ec)       { create(:envelope_community, name: 'test').name }
 
     it 'find envelopes with community' do
       expect(Envelope.in_community(name).find(envelope.id)).to eq(envelope)
@@ -98,6 +99,12 @@ describe Envelope, type: :model do
 
     it 'find envelopes with `nil` community' do
       expect(Envelope.in_community(nil).find(envelope.id)).to eq(envelope)
+    end
+
+    it 'doesn\'t find envelopes from other communities' do
+      expect do
+        Envelope.in_community(ec).find(envelope.id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
* Add the ability to (optionally) configure an ID prefix for an EnvelopeCommunity (See [`fixtures/configs/ce_registry.json`](../blob/971e5e2aa1e3778ddcf813bd31c0ff3258bcfc1c/fixtures/configs/ce_registry.json#L78)); See #42 for more information on the topic.
* Use the prefix, if available, for the retrieval of Resources in `/resources`.

Implements #42 