### PR TITLE
Fix papertrail logging setup

### DIFF
--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -9,6 +9,11 @@ production: &production
       run_on: all_servers
 
   after_rails:
+    - command: erb .cloud66/log_files.yml.erb > .cloud66/log_files.yml
+      sudo: true
+      target: rails
+      apply_during: build_only
+
     - source: /.cloud66/log_files.yml
       destination: /etc/log_files.yml
       sudo: true

--- a/.cloud66/log_files.yml.erb
+++ b/.cloud66/log_files.yml.erb
@@ -1,5 +1,6 @@
 files:
   - <%= ENV['STACK_BASE'] %>/shared/log/production.log
+  - <%= ENV['STACK_BASE'] %>/shared/log/staging.log
   - <%= ENV['STACK_BASE'] %>/shared/log/nginx_error.log
 destination:
   host: <%= ENV['PAPERTRAIL_HOST'] %>

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build/
 .vagrant/
 
 /public/swagger/
+
+# the config file gets rendered from .cloud66/log_files.yml.erb
+.cloud66/log_files.yml


### PR DESCRIPTION
`remote_syslog2` doesn't do any erb style interpolation like the
documentation led me to believe.