### PR TITLE
Fix Cloud66 deploy_hook

### DIFF
--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -9,13 +9,7 @@ production: &production
       run_on: all_servers
 
   after_rails:
-    - command: erb .cloud66/log_files.yml.erb > .cloud66/log_files.yml
-      sudo: true
-      target: rails
-      apply_during: build_only
-
-    - source: /.cloud66/log_files.yml
-      destination: /etc/log_files.yml
+    - command: erb .cloud66/log_files.yml.erb > /etc/log_files.yml
       sudo: true
       target: rails
       apply_during: build_only


### PR DESCRIPTION
The previous deploy_hook for Cloud66 didn't work 