### PR TITLE
Update existing resource without envelope id

### DIFF
--- a/app/api/v1/resources_api.rb
+++ b/app/api/v1/resources_api.rb
@@ -17,7 +17,7 @@ module API
       # only once. See https://github.com/ruby-grape/grape/issues/570
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength, Metrics/PerceivedComplexity
       def self.included(base)
         base.instance_eval do
           include API::V1::Defaults
@@ -49,7 +49,11 @@ module API
                                      envelope.try(:resource_schema_name)]
               else
                 present envelope, with: API::Entities::Envelope
-                update_if_exists? ? status(:ok) : status(:created)
+                if envelope.created_at != envelope.updated_at
+                  status(:ok)
+                else
+                  status(:created)
+                end
               end
             end
 
@@ -113,7 +117,7 @@ module API
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:enable Metrics/BlockLength
+      # rubocop:enable Metrics/BlockLength, Metrics/PerceivedComplexity
     end
   end
 end

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -112,6 +112,10 @@ class Envelope < ActiveRecord::Base
     deleted_at.present?
   end
 
+  def process_resource
+    self.processed_resource = xml? ? parse_xml_payload : payload
+  end
+
   private
 
   def generate_envelope_id
@@ -122,10 +126,6 @@ class Envelope < ActiveRecord::Base
     # TODO: sign with some server key?
     update_columns(node_headers: JWT.encode(headers, nil, 'none'),
                    node_headers_format: :node_headers_jwt)
-  end
-
-  def process_resource
-    self.processed_resource = xml? ? parse_xml_payload : payload
   end
 
   def payload

--- a/app/services/envelope_builder.rb
+++ b/app/services/envelope_builder.rb
@@ -88,8 +88,11 @@ class EnvelopeBuilder
   def build_envelope
     @envelope ||= existing_or_new_envelope
     @envelope.assign_community(envelope_community)
-    @envelope.skip_validation = true if skip_validation?
     @envelope.assign_attributes(params.slice(*allowed_params))
+
+    @envelope = existing_envelope(@envelope)
+
+    @envelope.skip_validation = true if skip_validation?
     @envelope
   end
 
@@ -98,6 +101,20 @@ class EnvelopeBuilder
       Envelope.find_or_initialize_by(envelope_id: params[:envelope_id])
     else
       Envelope.new
+    end
+  end
+
+  def existing_envelope(envelope)
+    ctid = envelope.process_resource['ceterms:ctid']
+    old_envelope = Envelope.in_community('ce_registry')
+                           .with_ctid(ctid)
+                           .first
+
+    if old_envelope
+      old_envelope.assign_attributes(params.slice(*allowed_params))
+      old_envelope
+    else
+      envelope
     end
   end
 

--- a/app/services/envelope_builder.rb
+++ b/app/services/envelope_builder.rb
@@ -105,10 +105,8 @@ class EnvelopeBuilder
   end
 
   def existing_envelope(envelope)
-    ctid = envelope.process_resource['ceterms:ctid']
-    old_envelope = Envelope.in_community('ce_registry')
-                           .with_ctid(ctid)
-                           .first
+    id = envelope.process_resource['@id']
+    old_envelope = Envelope.community_resource('ce_registry', id)
 
     if old_envelope
       old_envelope.assign_attributes(params.slice(*allowed_params))

--- a/spec/api/v1/resources_spec.rb
+++ b/spec/api/v1/resources_spec.rb
@@ -22,6 +22,23 @@ describe API::V1::Resources do
     end
   end
 
+  context 'CREATE /resources to update' do
+    before(:each) do
+      update  = jwt_encode(resource.merge('ceterms:name': 'Updated'))
+      payload = attributes_for(:envelope, :from_cer, :with_cer_credential,
+                               resource: update,
+                               envelope_community: ec.name)
+      post '/resources/', payload
+      envelope.reload
+    end
+
+    it { expect_status(:ok) }
+
+    it 'updates some data inside the resource' do
+      expect(envelope.processed_resource['ceterms:name']).to eq('Updated')
+    end
+  end
+
   context 'GET /resources/:id' do
     before(:each) do
       get "/resources/#{id}"


### PR DESCRIPTION
Allow users to update an existing resource without knowledge of it's `envelope_id` using a `POST` request.

Fixes #99 