### PR TITLE
Retrieve resources with case-insensitive ID

### DIFF
--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -55,7 +55,8 @@ class Envelope < ActiveRecord::Base
   end)
 
   def self.by_resource_id(id)
-    find_by('processed_resource @> ?', { '@id' => id }.to_json)
+    find_by 'lower(processed_resource::text)::jsonb @> ?',
+            { '@id' => id.downcase }.to_json
   end
 
   def self.community_resource(community_name, id)

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -120,6 +120,11 @@ describe Envelope, type: :model do
       let!(:id) { '9999INVALID' }
       it { expect(Envelope.by_resource_id(id)).to be_nil }
     end
+
+    describe 'finds with case insensitive ID' do
+      let!(:upc_id) { id.upcase }
+      it { expect(Envelope.by_resource_id(id)).to eq(envelope) }
+    end
   end
 
   describe '.community_resource' do


### PR DESCRIPTION
Make retrieval of resources by ID case-insensitive.

While UUIDs should be in lower case in general, a human might try to retrieve a resource with upper case IDs.

Related to #118 