### PR TITLE
Revert "Retrieve resources with case-insensitive ID"

### DIFF
--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -55,8 +55,7 @@ class Envelope < ActiveRecord::Base
   end)
 
   def self.by_resource_id(id)
-    find_by 'lower(processed_resource::text)::jsonb @> ?',
-            { '@id' => id.downcase }.to_json
+    find_by('processed_resource @> ?', { '@id' => id }.to_json)
   end
 
   def self.community_resource(community_name, id)

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -120,11 +120,6 @@ describe Envelope, type: :model do
       let!(:id) { '9999INVALID' }
       it { expect(Envelope.by_resource_id(id)).to be_nil }
     end
-
-    describe 'finds with case insensitive ID' do
-      let!(:upc_id) { id.upcase }
-      it { expect(Envelope.by_resource_id(id)).to eq(envelope) }
-    end
   end
 
   describe '.community_resource' do


### PR DESCRIPTION
Reverts CredentialEngine/CredentialRegistry#119

The introduced changes appear to create a lot of load in postgres which are slowing down the API.

Related to #123 