### PR TITLE
Add Authentication [WIP]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'api-pagination', '~> 4.5'
 gem 'rack-contrib', '~> 1.4'
 gem 'swagger-blocks', '~> 2.0.0'
 gem 'rack-cors', '~> 0.4.1'
+gem 'warden', '~> 1.2.7'
 
 # Persistence
 gem 'pg', '~> 0.20', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    warden (1.2.7)
+      rack (>= 1.0)
     webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -269,7 +271,8 @@ DEPENDENCIES
   test_after_commit (~> 1.1)
   vcr (~> 3.0)
   virtus (~> 1.0)
+  warden (~> 1.2.7)
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.14.4
+   1.15.1

--- a/app/api/helpers/authentication.rb
+++ b/app/api/helpers/authentication.rb
@@ -1,0 +1,15 @@
+require 'warden'
+require 'api_consumer'
+
+Warden::Strategies.add(:api_token) do
+  def authenticate!
+    uid = env['grape.request'].headers['Http-Auth-Token']
+
+    api_consumer = ApiConsumer.find_by(uid: uid)
+    if api_consumer.present?
+      success!(api_consumer)
+    else
+      throw :warden
+    end
+  end
+end

--- a/app/api/v1/base.rb
+++ b/app/api/v1/base.rb
@@ -1,4 +1,5 @@
 require 'helpers/shared_helpers'
+require 'helpers/authentication'
 require 'v1/defaults'
 require 'v1/home'
 require 'v1/root'
@@ -17,6 +18,11 @@ module API
       include API::V1::Defaults
 
       helpers SharedHelpers
+
+      use Warden::Manager do |manager|
+        manager.default_strategies :api_token
+        manager.failure_app = ->(_env) { [401, {}, ['Not authorized']] }
+      end
 
       desc 'used only for testing'
       get(:_test) { test_response }

--- a/app/models/api_consumer.rb
+++ b/app/models/api_consumer.rb
@@ -1,0 +1,2 @@
+class ApiConsumer < ActiveRecord::Base
+end

--- a/db/migrate/20170725143941_create_api_consumers.rb
+++ b/db/migrate/20170725143941_create_api_consumers.rb
@@ -1,0 +1,12 @@
+class CreateApiConsumers < ActiveRecord::Migration
+  def change
+    create_table :api_consumers do |t|
+      t.string :name
+      t.string :email, null: false, index: true
+      t.string :provider, null: false
+      t.string :uid, null: false, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.2
--- Dumped by pg_dump version 9.6.2
+-- Dumped from database version 9.6.3
+-- Dumped by pg_dump version 9.6.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -77,6 +77,52 @@ CREATE SEQUENCE administrative_accounts_id_seq
 --
 
 ALTER SEQUENCE administrative_accounts_id_seq OWNED BY administrative_accounts.id;
+
+
+--
+-- Name: api_consumers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE api_consumers (
+    id integer NOT NULL,
+    name character varying,
+    email character varying NOT NULL,
+    provider character varying NOT NULL,
+    uid character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: api_consumers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE api_consumers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: api_consumers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE api_consumers_id_seq OWNED BY api_consumers.id;
+
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
 
 
 --
@@ -274,6 +320,13 @@ ALTER TABLE ONLY administrative_accounts ALTER COLUMN id SET DEFAULT nextval('ad
 
 
 --
+-- Name: api_consumers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY api_consumers ALTER COLUMN id SET DEFAULT nextval('api_consumers_id_seq'::regclass);
+
+
+--
 -- Name: envelope_communities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -314,6 +367,22 @@ ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq':
 
 ALTER TABLE ONLY administrative_accounts
     ADD CONSTRAINT administrative_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: api_consumers api_consumers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY api_consumers
+    ADD CONSTRAINT api_consumers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --
@@ -375,6 +444,20 @@ CREATE INDEX envelopes_resources_id_idx ON envelopes USING btree (((processed_re
 --
 
 CREATE UNIQUE INDEX index_administrative_accounts_on_public_key ON administrative_accounts USING btree (public_key);
+
+
+--
+-- Name: index_api_consumers_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_api_consumers_on_email ON api_consumers USING btree (email);
+
+
+--
+-- Name: index_api_consumers_on_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_api_consumers_on_uid ON api_consumers USING btree (uid);
 
 
 --
@@ -505,4 +588,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161108105842');
 INSERT INTO schema_migrations (version) VALUES ('20170312011508');
 
 INSERT INTO schema_migrations (version) VALUES ('20170412045538');
+
+INSERT INTO schema_migrations (version) VALUES ('20170725143941');
 


### PR DESCRIPTION
Closes #100 

A [separate application](https://github.com/coffeejunk/crce-auth_server) allows users to register using Google OIDC.

Warden is used to authenticate a user before any destructive call on the `/resources` endpoints. The "authentication" is currently done with the UID and will subsequently have to be replaced with a real token.

TODOs:
- [ ] tests for authentication
- [ ] updated existing tests 
- [ ] add a "development" mode/flag that removes the need for authentication
- [ ] use token instead of user uid to authenticate a request
- [ ] (Google Group) Approval process
- [ ] Documentation
- [ ] Register in envelope the API consumer ID

Currently both the authentication application as well as CR are sharing one database. This is typically a bad idea for several reasons (esp. potential inconsistencies) however in this case it seemed opportune as only the `ApiConsumer` is really shared. Depending on how complex the registration and especially authorization part of the application become it might be better to have the applications use independent databases and let them communicate over the wire.