### PR TITLE
Change CR prefix

### DIFF
--- a/fixtures/configs/ce_registry.json
+++ b/fixtures/configs/ce_registry.json
@@ -82,5 +82,5 @@
     }
   },
 
-  "id_prefix": "http://credentialengine.org/resources/"
+  "id_prefix": "http://credentialengineregistry.org/resources/"
 }

--- a/spec/api/v1/resources_spec.rb
+++ b/spec/api/v1/resources_spec.rb
@@ -59,7 +59,7 @@ describe API::V1::Resources do
     # NOTE: Remove this behavior if we want to disallow full URLs as ID params
     context 'full URL as ID' do
       let!(:full_id) do
-        'http://credentialengine.org/resources/ctid:id-123412312313'
+        'http://credentialengineregistry.org/resources/ctid:id-123412312313'
       end
       let!(:id) { 'ctid:id-123412312313' }
       before do

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
       }
     end
     add_attribute(:'@id') do
-      "http://credentialengine.org/resources/#{Envelope.generate_ctid}"
+      "http://credentialengineregistry.org/resources/#{Envelope.generate_ctid}"
     end
     add_attribute(:'ceterms:name') { 'Test Org' }
   end
@@ -36,7 +36,7 @@ FactoryGirl.define do
       }
     end
     add_attribute(:'@id') do
-      "http://credentialengine.org/resources/#{Envelope.generate_ctid}"
+      "http://credentialengineregistry.org/resources/#{Envelope.generate_ctid}"
     end
     add_attribute(:'ceterms:ctid') { send(:'@id') }
     add_attribute(:'ceterms:name') { 'Test Cred' }

--- a/spec/models/envelope_community_spec.rb
+++ b/spec/models/envelope_community_spec.rb
@@ -68,7 +68,7 @@ describe EnvelopeCommunity, type: :model do
 
   context '#id_prefix' do
     [
-      ['ce_registry', 'http://credentialengine.org/resources/'],
+      ['ce_registry', 'http://credentialengineregistry.org/resources/'],
       ['learning_registry', nil]
     ].each do |ec, prefix|
       describe ec do

--- a/spec/support/fixtures/json/ce_registry/credential/1_valid.json
+++ b/spec/support/fixtures/json/ce_registry/credential/1_valid.json
@@ -8,7 +8,7 @@
     "ceterms": "http://purl.org/ctdl/terms/"
   },
   "@type": "ceterms:MasterDegree",
-  "@id": "http://credentialengine.org/resource/urn:ctid:6bf1a7e2-814e-4598-a66e-a3e2ecb727d8",
+  "@id": "http://credentialengineregistry.org/resource/urn:ctid:6bf1a7e2-814e-4598-a66e-a3e2ecb727d8",
   "ceterms:credentialStatusType": [
     {
       "@type": "ceterms:CredentialAlignmentObject",
@@ -43,13 +43,13 @@
   ],
   "ceterms:ownedBy": [
     {
-      "@id": "http://credentialengine.org/resource/dc814d62-6198-4a58-803d-0d453dc414d5"
+      "@id": "http://credentialengineregistry.org/resource/dc814d62-6198-4a58-803d-0d453dc414d5"
     }
   ],
   "ceterms:requires": [
     {
       "@type": "ceterms:ConditionProfile",
-      "@id": "http://credentialengine.org/resource/8d747987-1638-4b2c-93c6-c9a1d5b80a96",
+      "@id": "http://credentialengineregistry.org/resource/8d747987-1638-4b2c-93c6-c9a1d5b80a96",
       "ceterms:assertedBy": {
         "@id": "dc814d62-6198-4a58-803d-0d453dc414d5"
       },
@@ -57,7 +57,7 @@
       "ceterms:targetLearningOpportunity": [
         {
           "@type": "@id",
-          "@id": "http://credentialengine.org/resource/46cf9dc1-37d5-48af-b75c-499002b3a489"
+          "@id": "http://credentialengineregistry.org/resource/46cf9dc1-37d5-48af-b75c-499002b3a489"
         }
       ]
     }


### PR DESCRIPTION
Related to #118 change `@id` prefix from `credentialengine.org` to `credentialengineregistry.org`.