### PR TITLE
(#138) Allow to sort search results by timestamps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,4 +58,5 @@ group :test do
   gem 'vcr', '~> 3.0'
   gem 'webmock', '~> 3.0'
   gem 'test_after_commit', '~> 1.1'
+  gem 'faker', '~> 1.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     erubis (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
+    faker (1.8.4)
+      i18n (~> 0.5)
     ffi (1.9.18)
     ffi (1.9.18-java)
     git-version-bump (0.15.1)
@@ -248,6 +250,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5)
   dotenv (~> 2.2)
   factory_girl (~> 4.8)
+  faker (~> 1.8)
   grape (~> 0.19)
   grape-entity (~> 0.6)
   grape-middleware-logger (~> 1.8.0)
@@ -272,4 +275,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.14.4
+   1.15.4

--- a/lib/swagger_helpers.rb
+++ b/lib/swagger_helpers.rb
@@ -122,6 +122,17 @@ module Swagger
                     type: :string,
                     required: false,
                     description: 'Filter by community-specific resource_type'
+          parameter name: :sort_by,
+                    in: :query,
+                    type: :string,
+                    required: false,
+                    description: 'Sort by timestamp ' \
+                                 '(`created_at` or `updated_at`)'
+          parameter name: :sort_order,
+                    in: :query,
+                    type: :string,
+                    required: false,
+                    description: 'Sort order (`asc` or `desc`)'
         end
       end
     end

--- a/spec/services/search_spec.rb
+++ b/spec/services/search_spec.rb
@@ -101,11 +101,11 @@ describe MR::Search, type: :service do
   end
 
   it 'search by date_range' do
-    res = MR::Search.new(from: '1 minute ago').run
+    res = MR::Search.new(from: '1 week ago').run
     expect(res.count).to be > 0
     expect(res.count).to eq Envelope.count
 
-    res = MR::Search.new(until: '1 minute ago').run
+    res = MR::Search.new(until: '1 week ago').run
     expect(res.count).to eq 0
   end
 
@@ -146,5 +146,126 @@ describe MR::Search, type: :service do
     expect(res.to_sql).to match(
       /processed_resource \@\> '{ \"publisher\": { \"name\": \"someone\" } }'/
     )
+  end
+
+  context 'sorting' do
+    let(:envelopes) { [envelope1, envelope2, envelope3, envelope4, envelope7] }
+    let(:results) do
+      MR::Search.new(
+        community: 'learning_registry',
+        sort_by: sort_by,
+        sort_order: sort_order
+      ).run
+    end
+    let(:sort_by) {}
+    let(:sort_order) {}
+
+    context 'default' do
+      it 'sorts by updated_at DESC' do
+        expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+      end
+    end
+
+    context 'invalid sort column' do
+      let(:sort_by) { Faker::Lorem.word }
+
+      context 'default order' do
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+
+      context 'invalid order' do
+        let(:sort_order) { Faker::Lorem.word }
+
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+
+      context 'ASC' do
+        let(:sort_order) { 'asc' }
+
+        it 'sorts by updated_at ASC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at))
+        end
+      end
+
+      context 'DESC' do
+        let(:sort_order) { 'desc' }
+
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+    end
+
+    context ':created_at' do
+      let(:sort_by) { 'created_at' }
+
+      context 'default order' do
+        it 'sorts by created_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:created_at).reverse)
+        end
+      end
+
+      context 'invalid order' do
+        let(:sort_order) { Faker::Lorem.word }
+
+        it 'sorts by created_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:created_at).reverse)
+        end
+      end
+
+      context 'ASC' do
+        let(:sort_order) { 'asc' }
+
+        it 'sorts by created_at ASC' do
+          expect(results).to eq(envelopes.sort_by(&:created_at))
+        end
+      end
+
+      context 'DESC' do
+        let(:sort_order) { 'desc' }
+
+        it 'sorts by created_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:created_at).reverse)
+        end
+      end
+    end
+
+    context ':updated_at' do
+      let(:sort_by) { 'updated_at' }
+
+      context 'default order' do
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+
+      context 'invalid order' do
+        let(:sort_order) { Faker::Lorem.word }
+
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+
+      context 'ASC' do
+        let(:sort_order) { 'asc' }
+
+        it 'sorts by updated_at ASC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at))
+        end
+      end
+
+      context 'DESC' do
+        let(:sort_order) { 'desc' }
+
+        it 'sorts by updated_at DESC' do
+          expect(results).to eq(envelopes.sort_by(&:updated_at).reverse)
+        end
+      end
+    end
   end
 end

--- a/spec/support/shared_contexts/envelopes_for_search.rb
+++ b/spec/support/shared_contexts/envelopes_for_search.rb
@@ -37,15 +37,78 @@ RSpec.shared_context 'envelopes for search' do
     )
   end
 
-  let!(:envelopes) do
+  let!(:envelope1) do
+    create(
+      :envelope,
+      created_at: Faker::Time.backward(6),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope2) do
+    create(
+      :envelope,
+      created_at: Faker::Time.backward(6),
+      resource: jwt_encode(resource_1),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope3) do
+    create(
+      :envelope,
+      created_at: Faker::Time.backward(6),
+      resource: jwt_encode(resource_2),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope4) do
+    create(
+      :envelope,
+      created_at: Faker::Time.backward(6),
+      resource: jwt_encode(resource_3),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope5) do
+    create(
+      :envelope,
+      :from_cer,
+      created_at: Faker::Time.backward(6),
+      resource: jwt_encode(resource_4),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope6) do
+    create(
+      :envelope,
+      :from_cer,
+      created_at: Faker::Time.backward(6),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let!(:envelope7) do
+    create(
+      :envelope,
+      :paradata,
+      created_at: Faker::Time.backward(6),
+      updated_at: Faker::Time.backward(6)
+    )
+  end
+
+  let(:envelopes) do
     [
-      create(:envelope),
-      create(:envelope, resource: jwt_encode(resource_1)),
-      create(:envelope, resource: jwt_encode(resource_2)),
-      create(:envelope, resource: jwt_encode(resource_3)),
-      create(:envelope, :from_cer, resource: jwt_encode(resource_4)),
-      create(:envelope, :from_cer),
-      create(:envelope, :paradata)
+      envelope1,
+      envelope2,
+      envelope3,
+      envelope4,
+      envelope5,
+      envelope6,
+      envelope7
     ]
   end
 end


### PR DESCRIPTION
- Allows to sort search results by the `created_at` or `updated_at` timestamps.
- Sets the default sort order to `updated_at DESC`.