### PR TITLE
Lower rubocop's method length limit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/ClassLength:
     - lib/swagger_helpers.rb
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 15
   Exclude:
     - lib/swagger_helpers.rb
 

--- a/app/models/key_pair.rb
+++ b/app/models/key_pair.rb
@@ -14,7 +14,7 @@ class KeyPair < ActiveRecord::Base
 
   private
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def generate_keys
     dir_path = MR.root_path.join('tmp', 'keys', organization_id.to_s)
     FileUtils.mkdir_p(dir_path)

--- a/app/services/publish_interactor.rb
+++ b/app/services/publish_interactor.rb
@@ -8,15 +8,7 @@ class PublishInteractor < BaseInteractor
     organization = Organization.find(params[:organization_id])
     publisher = params[:current_user].publisher
 
-    organization_publisher = fetch_or_create_organization_publisher(organization, publisher)
-
-    unless organization_publisher
-      @error = [
-        'User\'s publisher is not authorized to publish on behalf of this organization',
-        401
-      ]
-      return
-    end
+    return unless authorized_to_publish?(organization, publisher)
 
     @envelope, builder_errors = EnvelopeBuilder.new(
       envelope_attributes(params.merge(organization: organization, publisher: publisher))
@@ -32,23 +24,32 @@ class PublishInteractor < BaseInteractor
 
   private
 
-  def fetch_or_create_organization_publisher(organization, publisher)
-    organization_publisher = OrganizationPublisher
-                             .where(organization: organization)
-                             .where(publisher: publisher)
-                             .first
+  def authorized_to_publish?(organization, publisher)
+    authorized = OrganizationPublisher
+                 .where(organization: organization)
+                 .where(publisher: publisher)
+                 .exists?
 
     # if the publisher is already authorized to publish on behalf of this
-    # organization, great, use that OrganizationPublisher record
-    return organization_publisher if organization_publisher
+    # organization, great
+    return true if authorized
 
     # if not, and the publisher is not a super publisher, bail
-    return nil unless publisher.super_publisher
+    raise MR::NotAuthorizedToPublish unless publisher.super_publisher
 
     # super publisher get an OrganizationPublisher record created on the fly,
     # authorizing them to publish on behalf of this organization now and in the
     # future
     OrganizationPublisher.create(organization: organization, publisher: publisher)
+
+    true
+  rescue MR::NotAuthorizedToPublish
+    @error = [
+      'User\'s publisher is not authorized to publish on behalf of this organization',
+      401
+    ]
+
+    false
   end
 
   def envelope_attributes(params)

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -13,7 +13,6 @@ module MR
   class TransactionNotPersistedError < BaseError; end
   class BackupItemMissingError < BaseError; end
   class SchemaDoesNotExist < BaseError; end
-  class NotAuthorizedToPublish < BaseError; end
 
   # Encapsulates OpenSSL::PKey::RSAError to be more meaningfull
   class PkeyError < BaseError

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -13,6 +13,7 @@ module MR
   class TransactionNotPersistedError < BaseError; end
   class BackupItemMissingError < BaseError; end
   class SchemaDoesNotExist < BaseError; end
+  class NotAuthorizedToPublish < BaseError; end
 
   # Encapsulates OpenSSL::PKey::RSAError to be more meaningfull
   class PkeyError < BaseError


### PR DESCRIPTION
The PublishInteractor needed a bit of refactoring to get its methods
under this limit.