### PR TITLE
Secondary publishers

### DIFF
--- a/app/api/entities/envelope.rb
+++ b/app/api/entities/envelope.rb
@@ -36,6 +36,13 @@ module API
              documentation: { type: 'string',
                               desc: 'Encoding of the submitted resource',
                               values: ['jwt'] }
+      expose :publisher_id,
+             documentation: { type: 'string',
+                              desc: 'Envelope publisher id' }
+      expose :secondary_publisher_id,
+             safe: true,
+             documentation: { type: 'string',
+                              desc: 'Envelope secondary publisher id' }
       expose :decoded_node_headers,
              as: :node_headers,
              using: API::Entities::NodeHeaders,

--- a/app/api/v1/publish.rb
+++ b/app/api/v1/publish.rb
@@ -24,8 +24,9 @@ module API
           authenticate!
 
           secondary_token_header = request.headers['Secondary-Token']
-          secondary_token =
-            secondary_token_header.present? && secondary_token_header.split(' ').last
+          secondary_token = if secondary_token_header.present?
+                              secondary_token_header.split(' ').last
+                            end
 
           interactor = PublishInteractor.call(
             envelope_community: select_community,

--- a/app/api/v1/publish.rb
+++ b/app/api/v1/publish.rb
@@ -23,9 +23,14 @@ module API
         post 'resources/organizations/:organization_id/documents' do
           authenticate!
 
+          secondary_token_header = request.headers['Secondary-Token']
+          secondary_token =
+            secondary_token_header.present? && secondary_token_header.split(' ').last
+
           interactor = PublishInteractor.call(
             envelope_community: select_community,
             organization_id: params[:organization_id],
+            secondary_token: secondary_token,
             current_user: current_user,
             raw_resource: request.body.read
           )

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -11,4 +11,12 @@ class Publisher < ActiveRecord::Base
   validates :admin, presence: true
 
   normalize_attribute :name, with: :squish
+
+  def self.find_by_token(token)
+    token = AuthToken.find_by(value: token)
+
+    return nil unless token
+
+    token.user.publisher
+  end
 end

--- a/app/services/publish_interactor.rb
+++ b/app/services/publish_interactor.rb
@@ -13,9 +13,10 @@ class PublishInteractor < BaseInteractor
 
     return unless authorized_to_publish?(organization, publisher)
 
-    attributes = params.merge(organization: organization,
-                              publisher: publisher,
-                              secondary_publisher: secondary_publisher(params[:secondary_token]))
+    attributes =
+      params.merge(organization: organization,
+                   publisher: publisher,
+                   secondary_publisher: Publisher.find_by_token(params[:secondary_token]))
 
     @envelope, builder_errors = EnvelopeBuilder.new(
       envelope_attributes(attributes)
@@ -30,14 +31,6 @@ class PublishInteractor < BaseInteractor
   end
 
   private
-
-  def secondary_publisher(secondary_token)
-    token = AuthToken.find_by(value: secondary_token)
-
-    return nil unless token
-
-    token.user.publisher
-  end
 
   def authorized_to_publish?(organization, publisher)
     authorized = OrganizationPublisher
@@ -80,7 +73,7 @@ class PublishInteractor < BaseInteractor
       'resource_public_key': key_pair.public_key,
       'organization_id': params[:organization].id,
       'publisher_id': params[:publisher].id,
-      'secondary_publisher_id': params[:secondary_publisher] && params[:secondary_publisher].id
+      'secondary_publisher_id': params[:secondary_publisher]&.id
     }
   end
 

--- a/db/migrate/20171215172051_add_secondary_publisher.rb
+++ b/db/migrate/20171215172051_add_secondary_publisher.rb
@@ -1,0 +1,6 @@
+class AddSecondaryPublisher < ActiveRecord::Migration
+  def change
+    add_column :envelopes, :secondary_publisher_id, :uuid, index: true
+    add_foreign_key :envelopes, :publishers, column: :secondary_publisher_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -245,7 +245,8 @@ CREATE TABLE envelopes (
     fts_tsearch_tsv tsvector,
     resource_type character varying,
     organization_id uuid,
-    publisher_id uuid
+    publisher_id uuid,
+    secondary_publisher_id uuid
 );
 
 
@@ -855,6 +856,14 @@ ALTER TABLE ONLY envelope_transactions
 
 
 --
+-- Name: fk_rails_5d5c10d79f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY envelopes
+    ADD CONSTRAINT fk_rails_5d5c10d79f FOREIGN KEY (secondary_publisher_id) REFERENCES publishers(id);
+
+
+--
 -- Name: fk_rails_6964e51423; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -965,4 +974,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171109230956');
 INSERT INTO schema_migrations (version) VALUES ('20171113221325');
 
 INSERT INTO schema_migrations (version) VALUES ('20171121222132');
+
+INSERT INTO schema_migrations (version) VALUES ('20171215172051');
 


### PR DESCRIPTION
We now store a secondary publisher in envelopes, if it was provided with the request.