### PR TITLE
Fix backups task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'dry-struct'
 gem 'dry-monads'
 gem 'encryptor', '~> 3.0'
 gem 'attribute_normalizer', '~> 1.2'
+gem 'rest-client', '~> 2.0', '>= 2.0.2'
 
 # Markdown parser
 gem 'kramdown', '~> 1.13', '>= 1.11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,6 +355,7 @@ DEPENDENCIES
   pundit (~> 1.1)
   rack-contrib (~> 1.4)
   rack-cors (~> 0.4.1)
+  rest-client (~> 2.0, >= 2.0.2)
   rubocop (~> 0.48)
   ruby-progressbar (~> 1.7, >= 1.7.5)
   standalone_migrations (~> 5.2)
@@ -365,4 +366,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/services/internet_archive.rb
+++ b/app/services/internet_archive.rb
@@ -47,6 +47,7 @@ class InternetArchive
 
   def headers
     {
+      'x-archive-auto-make-bucket' => '1', # Create the bucket if it does not exist
       content_type: 'application/gzip',
       authorization: "LOW #{ENV['INTERNET_ARCHIVE_ACCESS_KEY']}:"\
                          "#{ENV['INTERNET_ARCHIVE_SECRET_KEY']}"


### PR DESCRIPTION
- Add missing dependency to Gemfile

  Archive.org tasks depend on `rest-client`. That dependency was available in development by coincidence (Airbone depends on it), but not in actual deployments.

- Add header for auto-creating buckets

  S3 PUTs would fail if the bucket were not created beforehand. Ref. https://archive.org/help/abouts3.txt

- Add task for backing up historical data

  `backup_all` will loop through all the dates that have envelopes and call the backup task for them.
