### PR TITLE
Don't depend on Neo4J for starting the application

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,4 +68,9 @@ require 'neo4j/core/cypher_session/adaptors/http'
 
 neo4j_adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new(ENV['NEO4J_URL'])
 Neo4j::ActiveBase.on_establish_session { Neo4j::Core::CypherSession.new(neo4j_adaptor) }
-Neo4j::Session.open(:server_db, ENV['NEO4J_URL'])
+
+begin
+  Neo4j::Session.open(:server_db, ENV['NEO4J_URL'])
+rescue Faraday::ConnectionFailed
+  MR.logger.warn("Couldn't connect to Neo4J. GraphQL related features will not work.")
+end


### PR DESCRIPTION
I often need to start Neo4J for doing things completely unrelated to the GraphQL search features (for example, running rake tasks).

Proposal: try to create the Neo4J session when booting up, but back down from it if we can't connect. 