### PR TITLE
Notify Gremlin indexer after transaction is actually committed

### DIFF
--- a/app/models/extensions/gremlin_indexable.rb
+++ b/app/models/extensions/gremlin_indexable.rb
@@ -6,7 +6,7 @@ module GremlinIndexable
   extend ActiveSupport::Concern
 
   included do
-    after_save :notify_indexer_update, on: %i[create update]
+    after_commit :notify_indexer_update, on: %i[create update]
 
     def notify_indexer_update
       if deleted_at_changed? && deleted_at.present?


### PR DESCRIPTION
Ref CredentialEngine/CredentialRegistry#229

There is a race condition when persisting resources, leading to the indexer being notified before the transaction is committed. That prevents the changes from appearing in the index in a timely manner.