### PR TITLE
Escape SSH key paths when calling 'ssh-keygen'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.3
 
@@ -38,7 +40,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
   ExcludedMethods: [
     'resource', 'namespace', 'swagger_schema', 'swagger_path', 'included'
-    ]
+  ]
 
 # scope triggers a false positive, this will be fixed in rubocop 0.48.2
 Lint/AmbiguousBlockAssociation:

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   # Code quality tools
   gem 'overcommit'
   gem 'rubocop', require: false
+  gem 'rubocop-performance'
   gem 'rubocop-rspec', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
@@ -314,6 +316,7 @@ DEPENDENCIES
   rest-client (~> 2.0, >= 2.0.2)
   rspec
   rubocop
+  rubocop-performance
   rubocop-rspec
   ruby-progressbar (~> 1.7, >= 1.7.5)
   standalone_migrations (~> 5.2, >= 5.2.7)
@@ -324,4 +327,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/app/models/key_pair.rb
+++ b/app/models/key_pair.rb
@@ -23,11 +23,11 @@ class KeyPair < ActiveRecord::Base
     private_key_path = dir_path + 'id_rsa'
     public_key_path = dir_path + 'id_rsa.pub'
 
-    unless system("ssh-keygen -f #{private_key_path} -P '' -t rsa -m pem -q")
+    unless system("ssh-keygen -f #{escape(private_key_path)} -P '' -t rsa -m pem -q")
       raise 'RSA key pair generation failed'
     end
 
-    unless system("ssh-keygen -f #{public_key_path} -e -m pem > #{pem_path} -q")
+    unless system("ssh-keygen -f #{escape(public_key_path)} -e -m pem > #{escape(pem_path)} -q")
       raise 'Public key conversion to PEM format failed'
     end
 
@@ -40,5 +40,11 @@ class KeyPair < ActiveRecord::Base
     self.public_key = File.read(pem_path)
   ensure
     FileUtils.rm_rf(dir_path)
+  end
+
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  def escape(path)
+    Shellwords.escape(path)
   end
 end


### PR DESCRIPTION
This avoids errors when path has spaces or other type of character that
needs escaping.