### PR TITLE
Sonarqube integration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=CredentialRegistry
+
+# --- optional properties ---
+
+# defaults to project key
+sonar.projectName=Credential Registry
+
+# defaults to 'not provided'
+sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Defaults to .
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+# Rubocop results report
+sonar.ruby.rubocop.reportPaths=rubocop-report.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,3 +17,6 @@ sonar.projectVersion=1.0
 
 # Rubocop results report
 sonar.ruby.rubocop.reportPaths=rubocop-report.json
+
+# Test coverage report
+sonar.ruby.coverage.reportPaths=coverage/.resultset.json


### PR DESCRIPTION
This PR makes the following changes:

- Adds a `sonar-project.properties` file that instructs the SonarQube scanner how to perform its analysis.
- Configures test coverage using the `simplecov` gem. Results are then uploaded to SonarQube as well.

Once you're ready to merge this PR, you can enable the code analysis through CodeShip. This is basically a two-step process:
1. Call the `scanner-ruby.sh` script from our [GitHub repository](https://github.com/learningtapestry/sonarqube-integrations). You can use `curl` or `wget` as suggested, or invoke it however you'd like. It's probably also generic enough to adapt to any typical ruby/rails project, at least for now.
2. Create an environment variable in CodeShip called `SONAR_TOKEN` that contains the token used to authenticate to the server. There's a shared secure note in LastPass where the token is stored (the shared folder is named `SonarQube`). For now, we're only using a single user to perform the analysis, so the token will be the same for all projects.

Keep in mind that `rubocop` offenses are also gathered and sent to SonarQube. Once there, they're treated as regular issues, but are flagged as coming from `rubocop`.

Lastly, to check the results, you can go to https://sonarqube.learningtapestry.com/dashboard?id=CredentialRegistry.

Please let us Joe or me know if you still don't have access, or have any questions.