### PR TITLE
Make query logging optional

### DIFF
--- a/app/api/v1/sparql.rb
+++ b/app/api/v1/sparql.rb
@@ -11,9 +11,10 @@ module API
       end
 
       desc 'Executes a SPARQL query'
+      params do
+        optional :log, default: true, type: Boolean
+      end
       post '/sparql' do
-        params = JSON(request.body.read)
-        request.body.rewind
         response = QuerySparql.call(params.symbolize_keys)
         status response.status
         response.result

--- a/db/migrate/20210601020245_create_query_logs.rb
+++ b/db/migrate/20210601020245_create_query_logs.rb
@@ -4,9 +4,9 @@ class CreateQueryLogs < ActiveRecord::Migration[5.2]
       t.string :engine, index: true, null: false
       t.datetime :started_at, index: true, null: false
       t.datetime :completed_at, index: true
-      t.jsonb :ctdl, index: true
-      t.jsonb :result, index: true
-      t.jsonb :query_logic, index: true
+      t.jsonb :ctdl
+      t.jsonb :result
+      t.jsonb :query_logic
       t.text :query
       t.text :error
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1164,31 +1164,10 @@ CREATE INDEX index_query_logs_on_completed_at ON public.query_logs USING btree (
 
 
 --
--- Name: index_query_logs_on_ctdl; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_query_logs_on_ctdl ON public.query_logs USING btree (ctdl);
-
-
---
 -- Name: index_query_logs_on_engine; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_query_logs_on_engine ON public.query_logs USING btree (engine);
-
-
---
--- Name: index_query_logs_on_query_logic; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_query_logs_on_query_logic ON public.query_logs USING btree (query_logic);
-
-
---
--- Name: index_query_logs_on_result; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_query_logs_on_result ON public.query_logs USING btree (result);
 
 
 --
@@ -1413,5 +1392,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210121082610'),
 ('20210311135955'),
 ('20210601020245');
-
-


### PR DESCRIPTION
We ping the `/sparql` endpoint with a simple query every minute in order to monitor Neptune's availability. It would be nice not to pollute the query log with those queries. I can imagine other situations when we don't want to log query requests. So let's make logging optional (enabled by default, of course).