### PR TITLE
Change column type for query logs query/result

### DIFF
--- a/db/migrate/20210624173908_change_query_logs_column_types.rb
+++ b/db/migrate/20210624173908_change_query_logs_column_types.rb
@@ -1,0 +1,7 @@
+class ChangeQueryLogsColumnTypes < ActiveRecord::Migration[5.2]
+  def change
+    change_column :query_logs, :ctdl, :text
+    change_column :query_logs, :result, :text
+    change_column :query_logs, :query_logic, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -547,9 +547,9 @@ CREATE TABLE public.query_logs (
     engine character varying NOT NULL,
     started_at timestamp without time zone NOT NULL,
     completed_at timestamp without time zone,
-    ctdl jsonb,
-    result jsonb,
-    query_logic jsonb,
+    ctdl text,
+    result text,
+    query_logic text,
     query text,
     error text
 );
@@ -1391,4 +1391,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201012074942'),
 ('20210121082610'),
 ('20210311135955'),
-('20210601020245');
+('20210601020245'),
+('20210624173908');


### PR DESCRIPTION
Payload is occasionally too large for JSONB columns. Change to plain text