### PR TITLE
Change column type for query logs query/result

### DIFF
--- a/app/models/query_log.rb
+++ b/app/models/query_log.rb
@@ -15,14 +15,14 @@ class QueryLog < ActiveRecord::Base
   end
 
   def ctdl=(value)
-    super(value.to_json)
+    super(value.present? ? value.to_json : nil)
   end
 
   def result=(value)
-    super(value.to_json)
+    super(value.present? ? value.to_json : nil)
   end
 
   def query_logic=(value)
-    super(value.to_json)
+    super(value.present? ? value.to_json : nil)
   end
 end

--- a/app/models/query_log.rb
+++ b/app/models/query_log.rb
@@ -13,4 +13,16 @@ class QueryLog < ActiveRecord::Base
   def fail(error)
     update(completed_at: Time.now, error: error)
   end
+
+  def ctdl=(value)
+    super(value.to_json)
+  end
+
+  def result=(value)
+    super(value.to_json)
+  end
+
+  def query_logic=(value)
+    super(value.to_json)
+  end
 end

--- a/db/migrate/20210624173908_change_query_logs_column_types.rb
+++ b/db/migrate/20210624173908_change_query_logs_column_types.rb
@@ -1,0 +1,7 @@
+class ChangeQueryLogsColumnTypes < ActiveRecord::Migration[5.2]
+  def change
+    change_column :query_logs, :ctdl, :text
+    change_column :query_logs, :result, :text
+    change_column :query_logs, :query_logic, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -547,9 +547,9 @@ CREATE TABLE public.query_logs (
     engine character varying NOT NULL,
     started_at timestamp without time zone NOT NULL,
     completed_at timestamp without time zone,
-    ctdl jsonb,
-    result jsonb,
-    query_logic jsonb,
+    ctdl text,
+    result text,
+    query_logic text,
     query text,
     error text
 );
@@ -1391,4 +1391,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201012074942'),
 ('20210121082610'),
 ('20210311135955'),
-('20210601020245');
+('20210601020245'),
+('20210624173908');

--- a/spec/api/v1/sparql_spec.rb
+++ b/spec/api/v1/sparql_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe API::V1::Sparql do
         expect(QueryLog.count).to eq(1)
 
         query_log = QueryLog.first
-        expect(query_log.ctdl).to eq(sparql_query['_ctdl'])
+        expect(query_log.ctdl).to eq(sparql_query['_ctdl'].to_json)
         expect(query_log.query).to eq(sparql_query['query'])
-        expect(query_log.result).to eq({ "test" => "success" })
+        expect(query_log.result).to eq({ "test" => "success" }.to_json)
         expect(query_log.error).to be_nil
         expect(query_log.started_at).not_to be_nil
         expect(query_log.completed_at).not_to be_nil
@@ -108,7 +108,7 @@ RSpec.describe API::V1::Sparql do
         expect(QueryLog.count).to eq(1)
 
         query_log = QueryLog.first
-        expect(query_log.ctdl).to eq(sparql_query['_ctdl'])
+        expect(query_log.ctdl).to eq(sparql_query['_ctdl'].to_json)
         expect(query_log.query).to eq(sparql_query['query'])
         expect(query_log.result).to eq(nil)
         expect(query_log.error).not_to be_nil

--- a/spec/models/query_log_spec.rb
+++ b/spec/models/query_log_spec.rb
@@ -45,4 +45,22 @@ RSpec.describe QueryLog, type: :model do
       expect(query_log.persisted?).to be true
     end
   end
+
+  describe '#ctdl=, #result=, #query_logic=' do
+    it "doesn't set a value if value is nil" do
+      query_log = QueryLog.new
+      %i(ctdl result query_logic).each do |method|
+        query_log.send("#{method}=", nil)
+        expect(query_log.send(method)).to eq(nil)
+      end
+    end
+
+    it "sets a JSON-encoded value" do
+      query_log = QueryLog.new
+      %i(ctdl result query_logic).each do |method|
+        query_log.send("#{method}=", { test: "test" })
+        expect(query_log.send(method)).to eq("{\"test\":\"test\"}")
+      end
+    end
+  end
 end

--- a/spec/models/query_log_spec.rb
+++ b/spec/models/query_log_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe QueryLog, type: :model do
       expect(query_log.started_at).not_to be_nil
       expect(query_log.completed_at).to be_nil
       expect(query_log.engine).to eq('sparql')
-      expect(query_log.ctdl).to eq(ctdl)
+      expect(query_log.ctdl).to eq(ctdl.to_json)
       expect(query_log.persisted?).to be true
     end
   end


### PR DESCRIPTION
Payload is occasionally too large for JSONB columns. Change to plain text