### PR TITLE
Add async job for publishing envelopes

### DIFF
--- a/app/api/base.rb
+++ b/app/api/base.rb
@@ -1,4 +1,5 @@
 require 'v1/base'
+require 'v2/base'
 
 module API
   # Main base class that defines all API versions
@@ -14,5 +15,6 @@ module API
     }
 
     mount API::V1::Base
+    mount API::V2::Base
   end
 end

--- a/app/api/entities/publish_request.rb
+++ b/app/api/entities/publish_request.rb
@@ -1,0 +1,49 @@
+require 'entities/version'
+require 'entities/node_headers'
+require 'entities/envelope_community'
+require 'entities/payload_formatter'
+
+module API
+  module Entities
+    # Presenter for Envelope
+    class PublishRequest < Grape::Entity
+      include PayloadFormatter
+
+      expose :id,
+             documentation: { type: 'string',
+                              desc: 'Unique identifier (in UUID format)' }
+
+      expose :envelope_id,
+             documentation: { type: 'string',
+                              desc: 'Unique identifier (in UUID format) for created or updated envelope' }
+
+      expose :envelope_ceterms_ctid,
+             documentation: { type: 'string',
+                              desc: 'Unique identifier (ceterms:ctid) for created or updated envelope' }
+
+      expose :error,
+             documentation: { type: 'string',
+                              desc: 'Error triggered during publishing process' }
+
+      expose :created_at,
+             documentation: { type: 'dateTime',
+                              desc: 'Creation date' }
+
+      expose :completed_at,
+             documentation: { type: 'dateTime',
+                              desc: 'Completion date' }
+
+      expose :status,
+             documentation: { type: 'string',
+                              desc: 'Status for the request' }
+
+      def envelope_id
+        object.envelope&.envelope_id
+      end
+
+      def envelope_ceterms_ctid
+        object.envelope&.envelope_ceterms_ctid
+      end
+    end
+  end
+end

--- a/app/api/v2/base.rb
+++ b/app/api/v2/base.rb
@@ -1,0 +1,27 @@
+require 'helpers/shared_helpers'
+require 'v2/defaults'
+require 'v2/publish'
+require 'v2/publish_requests'
+
+module API
+  module V2
+    # Base class that gathers all the API endpoints
+    class Base < Grape::API
+      include API::V2::Defaults
+      include Grape::Kaminari
+
+      helpers SharedHelpers
+      helpers Pundit
+
+      desc 'used only for testing'
+      get(:_test) { test_response }
+
+      mount API::V2::Publish.api_class
+      mount API::V2::PublishRequests.api_class
+
+      route_param :community_name do
+        mount API::V2::Publish.api_class
+      end
+    end
+  end
+end

--- a/app/api/v2/defaults.rb
+++ b/app/api/v2/defaults.rb
@@ -1,0 +1,45 @@
+module API
+  module V2
+    # Default options for all API endpoints and versions
+    module Defaults
+      extend ActiveSupport::Concern
+
+      included do
+        version 'v2', using: :accept_version_header
+        format :json
+
+        # Global handler for simple not found case
+        rescue_from ActiveRecord::RecordNotFound do |e|
+          log_backtrace(e)
+          error!({ errors: Array(e.message) }, 404)
+        end
+
+        # Global handler for validation errors
+        rescue_from Grape::Exceptions::ValidationErrors do |e|
+          error!({ errors: e.full_messages }, 400)
+        end
+
+        # Global handler for application specific errors
+        rescue_from MetadataRegistry::BaseError do |e|
+          log_backtrace(e)
+          error!({ errors: e.errors || Array(e.message) }, 400)
+        end
+
+        # Global handler for decoding/signing errors
+        rescue_from OpenSSL::PKey::RSAError,
+                    JWT::DecodeError,
+                    JWT::VerificationError do |e|
+          log_backtrace(e)
+          error!({ errors: Array(e.message) }, 400)
+        end
+
+        # Global handler for any unexpected exception
+        rescue_from :all do |e|
+          Airbrake.notify(e)
+          log_backtrace(e)
+          error!({ errors: Array(e.message) }, 500)
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/publish.rb
+++ b/app/api/v2/publish.rb
@@ -1,0 +1,74 @@
+require 'mountable_api'
+require 'envelope'
+require 'delete_token'
+require 'batch_delete_envelopes'
+require 'envelope_builder'
+require 'entities/envelope'
+require 'entities/payload_formatter'
+require 'helpers/shared_helpers'
+require 'helpers/community_helpers'
+require 'helpers/envelope_helpers'
+
+module API
+  module V2
+    class Publish < MountableAPI
+      mounted do # rubocop:disable Metrics/BlockLength
+        helpers SharedHelpers
+        helpers CommunityHelpers
+        helpers EnvelopeHelpers
+
+        namespace 'resources/organizations/:organization_id/documents' do
+          params do
+            requires :organization_id, type: String
+          end
+
+          before do
+            authenticate!
+
+            params[:envelope_community] = select_community
+            authenticate_community!
+
+            @organization = Organization.find_by!(_ctid: params[:organization_id])
+          end
+
+          desc 'Takes a resource and an organization id, signs the resource '\
+               'on behalf of an organization, and publishes a new envelope with '\
+               'that signed resource',
+               http_codes: [
+                 { code: 200, message: 'Envelope creation or update scheduled' }
+               ]
+
+          params do
+            optional :published_by, type: String
+            use :update_if_exists
+            use :skip_validation
+          end
+          post do
+            secondary_token_header = request.headers['Secondary-Token']
+            secondary_token = if secondary_token_header.present?
+                                secondary_token_header.split(' ').last
+                              end
+
+            publishing_organization =
+              if (published_by = params[:published_by]).present?
+                Organization.find_by!(_ctid: params[:published_by])
+              end
+
+            publish_request = PublishRequest.schedule(
+              envelope_community: select_community,
+              organization_id: @organization.id,
+              user_id: current_user.id,
+              publishing_organization_id: publishing_organization&.id,
+              secondary_token: secondary_token,
+              raw_resource: request.body.read,
+              skip_validation: skip_validation?
+            )
+
+            present publish_request, with: API::Entities::PublishRequest
+            status(:ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/v2/publish_requests.rb
+++ b/app/api/v2/publish_requests.rb
@@ -1,0 +1,38 @@
+require 'entities/publish_request'
+require 'helpers/shared_helpers'
+require 'publish_request'
+
+module API
+  module V2
+    # Publish requests API endpoints
+    class PublishRequests < MountableAPI
+      mounted do
+        helpers SharedHelpers
+
+        resources :publish_requests do
+          desc 'Returns all the publish requests'
+          before do
+            authenticate!
+          end
+          params do
+            use :pagination
+          end
+          paginate max_per_page: 200
+          get do
+            publish_requests = paginate PublishRequest.order(created_at: :desc)
+            present publish_requests, with: API::Entities::PublishRequest
+          end
+
+          desc 'Return a publish request by ID'
+          before do
+            authenticate!
+          end
+          get ':id', requirements: { id: /(.*)/ } do
+            publish_request = PublishRequest.find(params[:id])
+            present publish_request, with: API::Entities::PublishRequest
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/publish_envelope_job.rb
+++ b/app/jobs/publish_envelope_job.rb
@@ -1,0 +1,41 @@
+require 'extract_envelope_resources'
+
+class PublishEnvelopeJob < ActiveJob::Base
+  def perform(publish_request_id)
+    ActiveRecord::Base.transaction do
+      publish_request = PublishRequest.find(publish_request_id)
+      publish_args = build_args(publish_request.to_params)
+      publish_result = PublishInteractor.call(**publish_args)
+
+      if publish_result.success?
+        publish_request.complete(publish_result.envelope.id)
+      else
+        publish_request.fail(publish_result.error)
+      end
+    end
+  end
+
+  private
+
+  def build_args(request_params)
+    interactor_args = {
+      envelope_community: request_params[:envelope_community],
+      organization: Organization.find(request_params[:organization_id]),
+      current_user: User.find(request_params[:user_id]),
+      skip_validation: request_params[:skip_validation]
+    }
+
+    if request_params.key?(:envelope_id)
+      interactor_args[:envelope] = Envelope.find(request_params[:envelope_id])
+    else
+      interactor_args[:raw_resource] = request_params[:raw_resource]
+    end
+
+    interactor_args[:publishing_organization] = Organization.find(request_params[:publishing_organization_id]) \
+      if request_params.key?(:publishing_organization_id)
+
+    interactor_args[:secondary_token] = request_params[:secondary_token] if request_params.key?(:secondary_token)
+
+    interactor_args
+  end
+end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -1,0 +1,55 @@
+require 'publish_envelope_job'
+
+# Schedules publishing for an envelope
+class PublishRequest < ActiveRecord::Base
+  belongs_to :envelope, optional: true
+
+  scope :failed, -> { where.not(error: nil) }
+  scope :pending, -> { where(completed_at: nil) }
+  scope :succeeded, -> { where(error: nil).where.not(completed_at: nil) }
+
+  # Valid params:
+  #   envelope_community_id
+  #   organization_id
+  #   user_id
+  #   skip_validation
+  #   envelope_id
+  #   raw_resource
+  #   publishing_organization_id
+  #   secondary_token
+  def self.schedule(**params)
+    publish_request = create!(request_params: params.to_json)
+    PublishEnvelopeJob.perform_later(publish_request.id)
+    publish_request
+  end
+
+  def complete(envelope_id)
+    update(envelope_id: envelope_id, completed_at: Time.now)
+  end
+
+  def fail(error)
+    update(error: error, completed_at: Time.now)
+  end
+
+  def to_params
+    JSON.parse(request_params).deep_symbolize_keys
+  end
+
+  def failed?
+    error.present?
+  end
+
+  def succeeded?
+    completed_at.present? && error.blank?
+  end
+
+  def status
+    if failed?
+      'failed'
+    elsif succeeded?
+      'succeeded'
+    else
+      'pending'
+    end
+  end
+end

--- a/app/services/publish_interactor.rb
+++ b/app/services/publish_interactor.rb
@@ -23,7 +23,7 @@ class PublishInteractor < BaseInteractor
 
     @envelope, builder_errors = EnvelopeBuilder.new(
       envelope_attributes,
-      skip_validation: params[:skip_validation], 
+      skip_validation: params[:skip_validation],
       update_if_exists: envelope.present?
     ).build
 
@@ -40,7 +40,7 @@ class PublishInteractor < BaseInteractor
   def authorized?
     return false unless publisher.authorized_to_publish?(organization)
     return true if publishing_organization.nil?
- 
+
     publisher.authorized_to_publish?(publishing_organization)
   end
 

--- a/db/migrate/20210715141032_create_publish_requests.rb
+++ b/db/migrate/20210715141032_create_publish_requests.rb
@@ -1,0 +1,11 @@
+class CreatePublishRequests < ActiveRecord::Migration[6.0]
+  def change
+    create_table :publish_requests do |t|
+      t.text :request_params, null: false
+      t.references :envelope, null: true, index: true, foreign_key: true
+      t.jsonb :error, index: true
+      t.datetime :completed_at, index: true
+      t.timestamps null: false, index: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -523,6 +523,40 @@ CREATE TABLE public.organizations (
 
 
 --
+-- Name: publish_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.publish_requests (
+    id bigint NOT NULL,
+    request_params text NOT NULL,
+    envelope_id bigint,
+    error jsonb,
+    completed_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: publish_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.publish_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: publish_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.publish_requests_id_seq OWNED BY public.publish_requests.id;
+
+
+--
 -- Name: publishers; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -745,6 +779,13 @@ ALTER TABLE ONLY public.organization_publishers ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: publish_requests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_requests ALTER COLUMN id SET DEFAULT nextval('public.publish_requests_id_seq'::regclass);
+
+
+--
 -- Name: query_logs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -883,6 +924,14 @@ ALTER TABLE ONLY public.organization_publishers
 
 ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: publish_requests publish_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_requests
+    ADD CONSTRAINT publish_requests_pkey PRIMARY KEY (id);
 
 
 --
@@ -1150,6 +1199,41 @@ CREATE INDEX index_organizations_on_name ON public.organizations USING btree (na
 
 
 --
+-- Name: index_publish_requests_on_completed_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_publish_requests_on_completed_at ON public.publish_requests USING btree (completed_at);
+
+
+--
+-- Name: index_publish_requests_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_publish_requests_on_created_at ON public.publish_requests USING btree (created_at);
+
+
+--
+-- Name: index_publish_requests_on_envelope_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_publish_requests_on_envelope_id ON public.publish_requests USING btree (envelope_id);
+
+
+--
+-- Name: index_publish_requests_on_error; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_publish_requests_on_error ON public.publish_requests USING btree (error);
+
+
+--
+-- Name: index_publish_requests_on_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_publish_requests_on_updated_at ON public.publish_requests USING btree (updated_at);
+
+
+--
 -- Name: index_publishers_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1164,10 +1248,31 @@ CREATE INDEX index_query_logs_on_completed_at ON public.query_logs USING btree (
 
 
 --
+-- Name: index_query_logs_on_ctdl; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_query_logs_on_ctdl ON public.query_logs USING btree (ctdl);
+
+
+--
 -- Name: index_query_logs_on_engine; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_query_logs_on_engine ON public.query_logs USING btree (engine);
+
+
+--
+-- Name: index_query_logs_on_query_logic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_query_logs_on_query_logic ON public.query_logs USING btree (query_logic);
+
+
+--
+-- Name: index_query_logs_on_result; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_query_logs_on_result ON public.query_logs USING btree (result);
 
 
 --
@@ -1317,6 +1422,14 @@ ALTER TABLE ONLY public.publishers
 
 
 --
+-- Name: publish_requests fk_rails_c01765f016; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_requests
+    ADD CONSTRAINT fk_rails_c01765f016 FOREIGN KEY (envelope_id) REFERENCES public.envelopes(id);
+
+
+--
 -- Name: envelope_resources fk_rails_e6f6323848; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1392,4 +1505,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210121082610'),
 ('20210311135955'),
 ('20210601020245'),
-('20210624173908');
+('20210624173908'),
+('20210715141032');
+
+

--- a/spec/api/v2/publish_requests_spec.rb
+++ b/spec/api/v2/publish_requests_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe API::V2::PublishRequests do
+  let(:ctid) { envelope.envelope_ceterms_ctid }
+  let(:organization) { create(:organization) }
+
+  let!(:ce_registry) { create(:envelope_community, name: 'ce_registry') }
+  let!(:navy) { create(:envelope_community, name: 'navy') }
+
+  describe '/publish_requests' do
+    let(:user) { create(:user) }
+    let(:envelope_community) { create(:envelope_community) }
+    let(:publish_requests) {
+      create_list(:publish_request, 5, envelope_community: envelope_community)
+    }
+    before { publish_requests }
+
+    context 'GET /' do
+      it 'returns a paginated list of publish requests' do
+        get "/publish_requests",
+          {
+            'Accept-Version' => 'v2',
+            'Authorization' => 'Token ' + user.auth_token.value
+          }
+        expect_status(:ok)
+        expect_json_types(:array)
+        expect_json_sizes(5)
+        expect_json('4.id', publish_requests.first.id)
+      end
+    end
+
+    context 'GET /:id' do
+      it 'returns a publish request' do
+        get "/publish_requests/#{publish_requests.first.id}",
+          {
+            'Accept-Version' => 'v2',
+            'Authorization' => 'Token ' + user.auth_token.value
+          }
+        expect_status(:ok)
+        expect_json(id: publish_requests.first.id)
+        expect_json(status: 'pending')
+      end
+    end
+  end
+end

--- a/spec/api/v2/publish_spec.rb
+++ b/spec/api/v2/publish_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe API::V2::Publish do
+  let(:ctid) { envelope.envelope_ceterms_ctid }
+  let(:organization) { create(:organization) }
+
+  let!(:ce_registry) { create(:envelope_community, name: 'ce_registry') }
+  let!(:navy) { create(:envelope_community, name: 'navy') }
+
+  describe 'POST /resources/organizations/:organization_id/documents' do
+    let(:publishing_organization) { create(:organization) }
+
+    context 'default community' do
+      let(:user) { create(:user) }
+      let(:user2) { create(:user) }
+
+      let(:resource_json) do
+        File.read(
+          MR.root_path.join('db', 'seeds', 'ce_registry', 'credential.json')
+        )
+      end
+
+      context 'publish on behalf without token' do
+        before do
+          post "/resources/organizations/#{organization._ctid}/documents",
+               resource_json,
+               {
+                 'Accept-Version' => 'v2'
+               }
+        end
+
+        it 'returns a 401 unauthorized http status code' do
+          expect_status(:unauthorized)
+        end
+      end
+
+      context 'publish on behalf with token, can publish on behalf of organization' do
+        before do
+          create(:organization_publisher, organization: organization, publisher: user.publisher)
+          post "/resources/organizations/#{organization._ctid}/documents?skip_validation=true",
+              resource_json,
+              {
+                'Accept-Version' => 'v2',
+                'Authorization' => 'Token ' + user.auth_token.value
+              }
+        end
+
+        it 'schedules a publishing request' do
+          expect_status(:ok)
+          expect_json_keys(%i[id envelope_id envelope_ceterms_ctid created_at completed_at error])
+          expect(ActiveJob::Base.queue_adapter.enqueued_jobs.size).to eq 1
+          expect(ActiveJob::Base.queue_adapter.enqueued_jobs.first[:job]).to eq PublishEnvelopeJob
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/envelope_communities.rb
+++ b/spec/factories/envelope_communities.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     name { 'learning_registry' }
     default { false }
     backup_item { 'learning-registry-test' }
+
+    trait :with_random_name do
+      name { Faker::Lorem.word }
+      backup_item { "#{name}-test" }
+    end
   end
 end

--- a/spec/factories/publish_requests.rb
+++ b/spec/factories/publish_requests.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :publish_request do
+    transient { envelope_community { create(:envelope_community) } }
+    transient { organization { create(:organization) } }
+    transient { publishing_organization { create(:organization) } }
+    transient { user { create(:user) } }
+    transient { secondary_token { create(:auth_token) } }
+    request_params do
+      {
+        raw_resource: attributes_for(:resource).to_json,
+        envelope_community: envelope_community.name,
+        organization_id: organization.id,
+        publishing_organization_id: publishing_organization&.id,
+        user_id: user.id,
+        secondary_token: secondary_token&.value,
+        skip_validation: true
+      }.to_json
+    end
+  end
+end

--- a/spec/jobs/publish_envelope_job_spec.rb
+++ b/spec/jobs/publish_envelope_job_spec.rb
@@ -1,0 +1,61 @@
+require 'extract_envelope_resources_job'
+
+RSpec.describe PublishEnvelopeJob do
+  subject { PublishEnvelopeJob }
+
+  describe '#perform' do
+    context 'publishing on behalf' do
+      let(:envelope_community) { create(:envelope_community) }
+      let(:organization) { create(:organization) }
+      let(:publishing_organization) { create(:organization) }
+      let(:user) { create(:user) }
+      let(:publish_request) do
+        create(
+          :publish_request,
+          envelope_community: envelope_community,
+          organization: organization,
+          publishing_organization: publishing_organization,
+          user: user
+        )
+      end
+      before do
+        create(:organization_publisher, organization: organization, publisher: user.publisher)
+        create(:organization_publisher, organization: publishing_organization, publisher: user.publisher)
+      end
+
+      it 'creates an envelope and marks the request as completed successfully' do
+        subject.new.perform(publish_request.id)
+        publish_request.reload
+        expect(publish_request.succeeded?).to be true
+        expect(publish_request.failed?).to be false
+        expect(publish_request.envelope).not_to be_nil
+        expect(publish_request.error).to be_nil
+      end
+    end
+
+    context 'not authorized to publish' do
+      let(:envelope_community) { create(:envelope_community) }
+      let(:organization) { create(:organization) }
+      let(:publishing_organization) { create(:organization) }
+      let(:user) { create(:user) }
+      let(:publish_request) do
+        create(
+          :publish_request,
+          envelope_community: envelope_community,
+          organization: organization,
+          publishing_organization: publishing_organization,
+          user: user
+        )
+      end
+
+      it "doesn't create an envelope and marks the request as failed" do
+        subject.new.perform(publish_request.id)
+        publish_request.reload
+        expect(publish_request.succeeded?).to be false
+        expect(publish_request.failed?).to be true
+        expect(publish_request.envelope).to be_nil
+        expect(publish_request.error[0]).to eq "Publisher is not authorized to publish on behalf of this organization"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds async publishing functionality to the CredReg API. The feature is implemented in the following way:

- A new API version, `v2`, was added with the routes:
  - `POST /resources/organizations/:organization_id/documents`: publish on behalf (asynchronous)
  - `GET /publish_requests`: list of current publish requests
  - `GET /publish_requests/:id`: get publish request by ID
  - API selection is done via the header `Accept-Version`.
- A new model was created, `PublishRequest`, which stores the original parameters for the envelope that is scheduled for publishing. `PublishRequest`s are updated whenever the publishing process completes (either successfully or with error).
- A new Sidekiq job `PublishEnvelopeJob` was created that calls `PublishInteractor` with the information stored in a `PublishRequest`, and updates the `PublishRequest` with the results.
- Tests were added for all those new components.

Potentially missing:
- Porting other API endpoints, such as `POST /resources`, to use the async features in the API v2. I am not sure, but I believe most of those methods aren't used at all and we don't really need to port them. Unless I'm mistaken, the main method for publishing envelopes today is the one I implemented.
- Adding API v2 to Swagger. It is unclear whether Swagger is still used and how we will add v2 to it. 