### PR TITLE
Optimize subqueries for CTDL engine

### DIFF
--- a/app/services/ctdl_query.rb
+++ b/app/services/ctdl_query.rb
@@ -443,7 +443,7 @@ class CtdlQuery
       reverse_ref: reverse
     )
 
-    table[:'@id'].in(Arel.sql("(SELECT resource_uri FROM #{subquery_name})"))
+    table[:'@id'].in(Arel.sql("(SELECT DISTINCT resource_uri FROM #{subquery_name})"))
   end
 
   def combine_conditions(conditions, operator)


### PR DESCRIPTION
When checking for id presence in array derived from subquery there's no need for repeated values.