### PR TITLE
Remove changed flag from Envelope entity

### DIFF
--- a/app/api/entities/envelope.rb
+++ b/app/api/entities/envelope.rb
@@ -71,13 +71,6 @@ module API
       expose :published_by,
              documentation: { type: 'string',
                               desc: 'Publisher of the envelope' }
-      expose :changed,
-             documentation: { type: 'boolean',
-                              desc: 'Whether the envelope has changed' }
-
-      def changed
-        object.previous_changes.any?
-      end
 
       def decoded_resource
         format_payload(object.decoded_resource)

--- a/lib/swagger_docs.rb
+++ b/lib/swagger_docs.rb
@@ -1132,9 +1132,6 @@ module MetadataRegistry
       property :published_by,
                type: 'string',
                description: 'CTID of the publisher'
-      property :changed,
-               type: 'boolean',
-               description: 'Whether the envelope has changed'
     end
 
     swagger_schema :NodeHeaders do

--- a/spec/api/v1/envelopes_spec.rb
+++ b/spec/api/v1/envelopes_spec.rb
@@ -223,7 +223,6 @@ RSpec.describe API::V1::Envelopes do
         publish.call
 
         expect_json_types(envelope_id: :string)
-        expect_json(changed: true)
         expect_json(envelope_community: 'learning_registry')
         expect_json(envelope_version: '0.52.0')
         expect_json(node_headers: { updated_at: now.utc.to_s })
@@ -278,7 +277,6 @@ RSpec.describe API::V1::Envelopes do
             envelope.reload
 
             expect(envelope.envelope_version).to eq('0.52.0')
-            expect_json(changed: false)
             expect_json(node_headers: { updated_at: updated_at.utc.to_s })
             expect_json(owned_by: organization._ctid)
             expect_json(published_by: publishing_organization._ctid)
@@ -301,7 +299,6 @@ RSpec.describe API::V1::Envelopes do
             envelope.reload
 
             expect(envelope.envelope_version).to eq('0.53.0')
-            expect_json(changed: true)
             expect_json(node_headers: { updated_at: now.utc.to_s })
           end
         end
@@ -332,7 +329,6 @@ RSpec.describe API::V1::Envelopes do
             envelope.reload
 
             expect(envelope.envelope_version).to eq('0.52.0')
-            expect_json(changed: false)
             expect_json(node_headers: { updated_at: updated_at.utc.to_s })
           end
         end
@@ -361,7 +357,6 @@ RSpec.describe API::V1::Envelopes do
               publishing_organization
             )
 
-            expect_json(changed: true)
             expect_json(node_headers: { updated_at: now.utc.to_s })
             expect_json(owned_by: organization._ctid)
             expect_json(published_by: publishing_organization._ctid)

--- a/spec/api/v1/publish_spec.rb
+++ b/spec/api/v1/publish_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe API::V1::Publish do
           expect_json(envelope_community: 'ce_registry')
           expect_json(envelope_version: '1.0.0')
           expect_json(secondary_publisher_id: nil)
-          expect_json(changed: true)
         end
       end
 
@@ -67,7 +66,6 @@ RSpec.describe API::V1::Publish do
           expect_json(envelope_community: 'ce_registry')
           expect_json(envelope_version: '1.0.0')
           expect_json(secondary_publisher_id: user2.publisher.id)
-          expect_json(changed: true)
         end
       end
 
@@ -99,7 +97,6 @@ RSpec.describe API::V1::Publish do
           expect_json(envelope_community: 'ce_registry')
           expect_json(envelope_version: '1.0.0')
           expect_json(secondary_publisher_id: nil)
-          expect_json(changed: true)
         end
       end
 
@@ -127,7 +124,6 @@ RSpec.describe API::V1::Publish do
                    'Authorization' => 'Token ' + user.auth_token.value
             end.to change { Envelope.count }.by(1)
             expect_status(:created)
-            expect_json(changed: true)
           end
         end
       end
@@ -196,7 +192,6 @@ RSpec.describe API::V1::Publish do
           expect_json(secondary_publisher_id: nil)
           expect_json(owned_by: organization._ctid)
           expect_json(published_by: publishing_organization._ctid)
-          expect_json(changed: true)
 
           envelope = Envelope.last
           expect(envelope.publishing_organization).to eq(publishing_organization)
@@ -633,7 +628,6 @@ RSpec.describe API::V1::Publish do
             }.not_to change { envelope.reload.resource }
 
             expect_status(:ok)
-            expect_json(changed: false)
           end
         end
 
@@ -653,7 +647,6 @@ RSpec.describe API::V1::Publish do
             .and(not_change { envelope.reload.processed_resource })
 
             expect_status(:ok)
-            expect_json(changed: true)
           end
         end
       end
@@ -746,7 +739,6 @@ RSpec.describe API::V1::Publish do
               }.not_to change { envelope.reload.resource }
 
               expect_status(:ok)
-              expect_json(changed: false)
             end
           end
 
@@ -767,7 +759,6 @@ RSpec.describe API::V1::Publish do
               .and(not_change { envelope.reload.publisher })
 
               expect_status(:ok)
-              expect_json(changed: true)
             end
           end
         end
@@ -806,7 +797,6 @@ RSpec.describe API::V1::Publish do
               }.not_to change { envelope.reload.resource }
 
               expect_status(:ok)
-              expect_json(changed: true)
             end
           end
 
@@ -831,7 +821,6 @@ RSpec.describe API::V1::Publish do
               .and(not_change { envelope.reload.processed_resource })
 
               expect_status(:ok)
-              expect_json(changed: true)
             end
           end
         end


### PR DESCRIPTION
If we need that feature we should store revisions invormation based on meaningful input (actual resource)
instead of relying on ephermal ActiveRecord instance state.