### PR TITLE
Make CTIDs case-insensitive in all API endpoints

### DIFF
--- a/app/api/helpers/envelope_helpers.rb
+++ b/app/api/helpers/envelope_helpers.rb
@@ -43,7 +43,10 @@ module EnvelopeHelpers
   end
 
   def find_envelope
-    @envelope = scoped_envelopes.community_resource(select_community, params[:id])
+    @envelope = scoped_envelopes.community_resource(
+      select_community,
+      params[:id]&.downcase
+    )
 
     return unless @envelope.blank?
 

--- a/app/api/v1/envelopes.rb
+++ b/app/api/v1/envelopes.rb
@@ -145,7 +145,7 @@ module API
 
           route_param :envelope_id do
             after_validation do
-              id = params[:envelope_id]
+              id = params[:envelope_id]&.downcase
 
               @envelope = find_envelopes.find_by(envelope_id: id) ||
                 find_envelopes.where(envelope_ceterms_ctid: id).last

--- a/app/api/v1/graph.rb
+++ b/app/api/v1/graph.rb
@@ -49,8 +49,10 @@ module API
           post :search do
             status(:ok)
 
+            ctids = params[:ctids]&.map(&:downcase)
+
             find_envelopes
-              .where(envelope_ceterms_ctid: params[:ctids])
+              .where(envelope_ceterms_ctid: ctids)
               .pluck(:processed_resource)
           end
         end

--- a/spec/api/v1/graph_spec.rb
+++ b/spec/api/v1/graph_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe API::V1::Graph do
           skip_validation: true
         )
 
-        get "/graph/#{CGI.escape(id)}"
+        get "/graph/#{CGI.escape(id).upcase}"
       end
 
       context 'without `id_field`' do
@@ -176,9 +176,9 @@ RSpec.describe API::V1::Graph do
         post '/graph/search',
              {
                ctids: [
-                 envelope1.envelope_ceterms_ctid,
-                 envelope2.envelope_ceterms_ctid,
-                 envelope3.envelope_ceterms_ctid
+                 envelope1.envelope_ceterms_ctid.upcase,
+                 envelope2.envelope_ceterms_ctid.upcase,
+                 envelope3.envelope_ceterms_ctid.upcase
                ]
              }
       end

--- a/spec/api/v1/resources_spec.rb
+++ b/spec/api/v1/resources_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe API::V1::Resources do
           skip_validation: true
         )
 
-        get "/resources/#{CGI.escape(id)}"
+        get "/resources/#{CGI.escape(id).upcase}"
       end
 
       context 'without `id_field`' do

--- a/spec/api/v1/single_envelope_spec.rb
+++ b/spec/api/v1/single_envelope_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe API::V1::SingleEnvelope do
     end
 
     context 'by CTID' do
-      let(:id) { envelope.envelope_ceterms_ctid }
+      let(:ctid) { subject.envelope_ceterms_ctid.upcase }
 
       include_examples 'missing envelope', :get
 
@@ -53,7 +53,7 @@ RSpec.describe API::V1::SingleEnvelope do
 
       before(:each) do
         with_versioned_envelope(subject) do
-          get "/learning-registry/envelopes/#{subject.envelope_id}"
+          get "/learning-registry/envelopes/#{ctid}"
         end
       end
 


### PR DESCRIPTION
Ref. CredentialEngine/CredentialRegistry#602