### PR TITLE
Only run dependency review on pull requests

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,9 +1,6 @@
 name: Dependency Review
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 permissions:


### PR DESCRIPTION
Quick tweak to avoid running into [this issue](https://github.com/actions/dependency-review-action/issues/456) when dependency-review runs against the `master` branch. We actually only need it for PRs, so we only trigger the action there.