### PR TITLE
(#903) Split dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 
-# Use Red Hat Universal Base Image 8
-FROM registry.access.redhat.com/ubi8:8.10-1752733233
+#############################
+# Build stage (UBI 10 minimal)
+#############################
+FROM registry.access.redhat.com/ubi10/ubi-minimal AS builder
 
 ARG PLAT=x86_64
+ARG RUBY_VERSION=3.4.3
 ENV APP_PATH=/app/
 ENV LANGUAGE=en_US:en
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
-ARG RUBY_VERSION=3.4.3
 ENV BUNDLE_PATH=/app/vendor/bundle
 ENV PLAT=$PLAT
 ENV RUBY_VERSION=$RUBY_VERSION
-ENV PG_REPO=https://download.postgresql.org/pub/repos/yum
-ENV RPMFIND_REPO=https://rpmfind.net/linux/almalinux/8.10
 ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:$PATH"
 ENV GEM_HOME='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
 ENV GEM_PATH='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
@@ -21,26 +21,32 @@ ENV IRBRC='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/.irbrc'
 
 WORKDIR $APP_PATH
 
-# Install necessary tools and deps
+# Install build tools and runtime libs in builder
+RUN microdnf -y update && microdnf -y install \
+      git gcc-c++ make which tar bzip2 \
+      openssl openssl-devel \
+      zlib zlib-devel \
+      libyaml libyaml-devel \
+      readline readline-devel \
+      gmp gmp-devel \
+      libffi libffi-devel \
+      ncurses ncurses-devel \
+      findutils diffutils procps-ng \
+      ca-certificates \
+      libpq libpq-devel && \
+    microdnf clean all
 
-# Copy all pre-built RPMs from repository directory to a temporary location in
-# the image so the repository root stays clean and the image layers remain tidy.
-COPY rpms/ /tmp/rpms/
-RUN dnf -y install libpq.${PLAT} libpq-devel.${PLAT} dnf-plugins-core git gcc-c++ make openssl-devel \
-    diffutils procps-ng zlib-devel which tar bzip2 libyaml-devel /tmp/rpms/*.rpm \
-    # Install the PostgreSQL repository
-    ${PG_REPO}/reporpms/EL-8-${PLAT}/pgdg-redhat-repo-latest.noarch.rpm &&\
-    # Install PostgreSQL
-    dnf -y install postgresql16 &&  dnf clean all && \
-    # Install Ruby RVM
-    curl --proto "=https" --tlsv1.2 -sSf -L https://rvm.io/pkuczynski.asc | gpg2 --import - && \
+# Install Ruby via RVM
+RUN curl --proto "=https" --tlsv1.2 -sSf -L https://rvm.io/pkuczynski.asc | gpg2 --import - && \
     curl --proto "=https" --tlsv1.2 -sSf -L https://get.rvm.io | bash -s stable && \
-    /usr/local/rvm/bin/rvm install ${RUBY_VERSION} && \
-    # Cleanup temporary RPMs to keep image size small
-    rm -rf /tmp/rpms
+    /usr/local/rvm/bin/rvm install ${RUBY_VERSION}
 
 COPY Gemfile Gemfile.lock .ruby-version $APP_PATH
-RUN gem install bundler  && bundle config set deployment true && DOCKER_ENV=true RACK_ENV=production bundle install
+RUN gem install bundler && \
+    bundle config set deployment true && \
+    DOCKER_ENV=true RACK_ENV=production bundle install
+
+# Copy application sources
 COPY app/       $APP_PATH/app
 COPY bin/       $APP_PATH/bin
 COPY config/    $APP_PATH/config
@@ -52,11 +58,53 @@ COPY public/    $APP_PATH/public
 COPY config.ru  $APP_PATH
 COPY Rakefile   $APP_PATH
 
-COPY docker-entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/docker-entrypoint.sh && useradd -m registry && chown -R registry:registry /app
+COPY docker-entrypoint.sh /tmp/docker-entrypoint.sh
+
+# Collect runtime artifacts to a staging dir
+RUN mkdir -p /runtime/usr/local /runtime/etc /runtime/usr/bin /runtime/usr/lib64 && \
+    cp -a /usr/local/rvm /runtime/usr/local/ && \
+    cp -a /etc/pki /runtime/etc/ && \
+    cp -a /etc/ssl /runtime/etc/ || true && \
+    cp -a /usr/bin/openssl /runtime/usr/bin/ && \
+    # Copy commonly required runtime shared libraries
+    for lib in \
+      /usr/lib64/libpq.so.* \
+      /usr/lib64/libssl.so.* \
+      /usr/lib64/libcrypto.so.* \
+      /usr/lib64/libyaml-0.so.* \
+      /usr/lib64/libreadline.so.* \
+      /usr/lib64/libncursesw.so.* \
+      /usr/lib64/libz.so.* \
+      /usr/lib64/libzstd.so.* \
+      /usr/lib64/libgmp.so.* \
+      /usr/lib64/libffi.so.* \
+    ; do cp -a $lib /runtime/usr/lib64/ 2>/dev/null || true; done && \
+    # App
+    cp -a $APP_PATH /runtime/app && \
+    chmod +x /tmp/docker-entrypoint.sh && cp /tmp/docker-entrypoint.sh /runtime/usr/bin/docker-entrypoint.sh
+
+#############################
+# Runtime stage (UBI 10 micro)
+#############################
+FROM registry.access.redhat.com/ubi10/ubi-micro
+
+ENV APP_PATH=/app/
+ARG RUBY_VERSION=3.4.3
+ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:$PATH"
+ENV GEM_HOME='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
+ENV GEM_PATH='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
+ENV MY_RUBY_HOME='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}'
+ENV IRBRC='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/.irbrc'
+
+WORKDIR $APP_PATH
+
+# Copy runtime files from builder
+COPY --from=builder /runtime/ /
+
+# Create runtime user
+RUN adduser -m registry && chown -R registry:registry /app
 USER registry
 
-
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
 EXPOSE 9292

--- a/Dockerfile.navy
+++ b/Dockerfile.navy
@@ -1,18 +1,18 @@
 
-# Use Red Hat Universal Base Image 8
-FROM registry.access.redhat.com/ubi8:8.10-1752733233
+#############################
+# Build stage (UBI 10 minimal)
+#############################
+FROM registry.access.redhat.com/ubi10/ubi-minimal AS builder
 
 ARG PLAT=x86_64
+ARG RUBY_VERSION=3.4.3
 ENV APP_PATH=/app/
 ENV LANGUAGE=en_US:en
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
-ARG RUBY_VERSION=3.4.3
 ENV BUNDLE_PATH=/app/vendor/bundle
 ENV PLAT=$PLAT
 ENV RUBY_VERSION=$RUBY_VERSION
-ENV PG_REPO=https://download.postgresql.org/pub/repos/yum
-ENV RPMFIND_REPO=https://rpmfind.net/linux/almalinux/8.10
 ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:$PATH"
 ENV GEM_HOME='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
 ENV GEM_PATH='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
@@ -21,27 +21,28 @@ ENV IRBRC='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/.irbrc'
 
 WORKDIR $APP_PATH
 
-# Install necessary tools and deps
+# Install build tools and runtime libs in builder
+RUN microdnf -y update && microdnf -y install \
+      git gcc-c++ make which tar bzip2 unzip \
+      openssl openssl-devel \
+      zlib zlib-devel \
+      libyaml libyaml-devel \
+      readline readline-devel \
+      gmp gmp-devel \
+      libffi libffi-devel \
+      ncurses ncurses-devel \
+      findutils diffutils procps-ng \
+      ca-certificates \
+      libpq libpq-devel && \
+    microdnf clean all
 
-# Copy all pre-built RPMs from repository directory to a temporary location in
-# the image so the repository root stays clean and the image layers remain tidy.
-COPY rpms/ /tmp/rpms/
-RUN dnf -y install libpq.${PLAT} libpq-devel.${PLAT} dnf-plugins-core git gcc-c++ make openssl-devel \
-    diffutils procps-ng zlib-devel which tar bzip2 libyaml-devel /tmp/rpms/*.rpm \
-    # Install the PostgreSQL repository
-    ${PG_REPO}/reporpms/EL-8-${PLAT}/pgdg-redhat-repo-latest.noarch.rpm &&\
-    # Install PostgreSQL
-    dnf -y install postgresql16 &&  dnf clean all && \
-    # Install Ruby RVM
-    curl --proto "=https" --tlsv1.2 -sSf -L https://rvm.io/pkuczynski.asc | gpg2 --import - && \
+# Install Ruby via RVM
+RUN curl --proto "=https" --tlsv1.2 -sSf -L https://rvm.io/pkuczynski.asc | gpg2 --import - && \
     curl --proto "=https" --tlsv1.2 -sSf -L https://get.rvm.io | bash -s stable && \
-    /usr/local/rvm/bin/rvm install ${RUBY_VERSION} && \
-    # Cleanup temporary RPMs to keep image size small
-    rm -rf /tmp/rpms
-
+    /usr/local/rvm/bin/rvm install ${RUBY_VERSION}
 
 ############################################################################    
-# BEGINNING OF Navy specifics
+# BEGINNING OF Navy specifics (handled in builder)
 ############################################################################
 
 # Add DoD certs directory from build context (optional) and install if present
@@ -73,10 +74,12 @@ RUN if [ -f /certs/unclass-certificates_pkcs7_DoD.zip ]; then \
 # END OF Navy specifics
 ############################################################################
 
-WORKDIR $APP_PATH
-
 COPY Gemfile Gemfile.lock .ruby-version $APP_PATH
-RUN gem install bundler  && bundle config set deployment true && DOCKER_ENV=true RACK_ENV=production bundle install
+RUN gem install bundler && \
+    bundle config set deployment true && \
+    DOCKER_ENV=true RACK_ENV=production bundle install
+
+# Copy application sources
 COPY app/       $APP_PATH/app
 COPY bin/       $APP_PATH/bin
 COPY config/    $APP_PATH/config
@@ -88,11 +91,53 @@ COPY public/    $APP_PATH/public
 COPY config.ru  $APP_PATH
 COPY Rakefile   $APP_PATH
 
-COPY docker-entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/docker-entrypoint.sh && useradd -m registry && chown -R registry:registry /app
+COPY docker-entrypoint.sh /tmp/docker-entrypoint.sh
+
+# Collect runtime artifacts to a staging dir
+RUN mkdir -p /runtime/usr/local /runtime/etc /runtime/usr/bin /runtime/usr/lib64 && \
+    cp -a /usr/local/rvm /runtime/usr/local/ && \
+    cp -a /etc/pki /runtime/etc/ && \
+    cp -a /etc/ssl /runtime/etc/ || true && \
+    cp -a /usr/bin/openssl /runtime/usr/bin/ && \
+    # Copy commonly required runtime shared libraries
+    for lib in \
+      /usr/lib64/libpq.so.* \
+      /usr/lib64/libssl.so.* \
+      /usr/lib64/libcrypto.so.* \
+      /usr/lib64/libyaml-0.so.* \
+      /usr/lib64/libreadline.so.* \
+      /usr/lib64/libncursesw.so.* \
+      /usr/lib64/libz.so.* \
+      /usr/lib64/libzstd.so.* \
+      /usr/lib64/libgmp.so.* \
+      /usr/lib64/libffi.so.* \
+    ; do cp -a $lib /runtime/usr/lib64/ 2>/dev/null || true; done && \
+    # App
+    cp -a $APP_PATH /runtime/app && \
+    chmod +x /tmp/docker-entrypoint.sh && cp /tmp/docker-entrypoint.sh /runtime/usr/bin/docker-entrypoint.sh
+
+#############################
+# Runtime stage (UBI 10 micro)
+#############################
+FROM registry.access.redhat.com/ubi10/ubi-micro
+
+ENV APP_PATH=/app/
+ARG RUBY_VERSION=3.4.3
+ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:$PATH"
+ENV GEM_HOME='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
+ENV GEM_PATH='/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global'
+ENV MY_RUBY_HOME='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}'
+ENV IRBRC='/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/.irbrc'
+
+WORKDIR $APP_PATH
+
+# Copy runtime files from builder
+COPY --from=builder /runtime/ /
+
+# Create runtime user
+RUN adduser -m registry && chown -R registry:registry /app
 USER registry
 
-
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
 EXPOSE 9292


### PR DESCRIPTION
Solves: #903 

Description: 

* Multi-stage builds: Split both images into builder (UBI 10 minimal) and runtime (UBI 10 micro).
* Builder stage: Compiles Ruby via sources, installs gems in deployment mode, and prepares runtime artifacts.
* Runtime stage: Copies only what’s needed to run:
    - App code and bundled gems
    - Ruby from sources
    - CA certs and OpenSSL binary (entrypoint uses it)
    - Shared libs required at runtime, including libpq and postgresql16 client
* Navy variant: DoD certs are processed in the builder and the resulting trust store is copied into the runtime stage, so they’re available at runtime.
- Bases used:
    - Builder: registry.access.redhat.com/ubi10/ubi-minimal
    - Runtime: registry.access.redhat.com/ubi10/ubi-micro
 