### PR TITLE
Hotfix RSPEC tests upon ActiveRecord gem update

### DIFF
--- a/app/api/base.rb
+++ b/app/api/base.rb
@@ -3,12 +3,7 @@ require 'v2/base'
 
 module API
   # Main base class that defines all API versions
-class Base < Grape::API
-    # Normalize ActiveRecord not-found errors to a stable API message
-    rescue_from ActiveRecord::RecordNotFound do |e|
-      model = e.respond_to?(:model) && e.model ? e.model : 'Resource'
-      error!({ errors: ["#{model} not found"] }, 404)
-    end
+  class Base < Grape::API
     insert_after Grape::Middleware::Formatter, Grape::Middleware::Logger, {
       logger: MR.logger,
       filter: Class.new do

--- a/app/api/defaults.rb
+++ b/app/api/defaults.rb
@@ -15,7 +15,9 @@ module API
       # Global handler for simple not found case
       rescue_from ActiveRecord::RecordNotFound do |e|
         log_backtrace(e)
-        error!({ errors: Array(e.message) }, 404)
+
+        model = e.respond_to?(:model) && e.model ? e.model : 'Record'
+        error!({ errors: ["#{model} not found"] }, 404)
       end
 
       # Global handler for validation errors

--- a/app/api/v1/resources.rb
+++ b/app/api/v1/resources.rb
@@ -88,7 +88,7 @@ module API
                         @envelope.inner_resource_from_graph(params[:id])
                       ))
             rescue ActiveRecord::RecordNotFound
-              raise ActiveRecord::RecordNotFound, "Couldn't find Resource"
+              raise ActiveRecord::RecordNotFound.new(nil, 'Resource')
             end
           end
         end

--- a/spec/api/v1/base_spec.rb
+++ b/spec/api/v1/base_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe API::V1::Base do
       let(:test_response) { raise ActiveRecord::RecordNotFound }
 
       it { expect_status(404) }
-      it { expect_json('errors.0', 'ActiveRecord::RecordNotFound') }
+      it { expect_json('errors.0', 'Record not found') }
     end
 
     context 'Grape::Exceptions::Validation' do # rubocop:todo RSpec/ContextWording

--- a/spec/api/v1/publish_spec.rb
+++ b/spec/api/v1/publish_spec.rb
@@ -817,10 +817,7 @@ RSpec.describe API::V1::Publish do # rubocop:todo RSpec/MultipleMemoizedHelpers
         it 'returns 404' do
           transfer_ownership
           expect_status(:not_found)
-          expect_json(
-            'errors.0',
-            "Couldn't find Organization with 'id'=#{new_organization_id}"
-          )
+          expect_json('errors.0', 'Organization not found')
         end
       end
 

--- a/spec/api/v1/resources_spec.rb
+++ b/spec/api/v1/resources_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V1::Resources do
 
         it 'cannot retrieve the desired resource' do
           expect_status(:not_found)
-          expect_json(errors: ["Couldn't find Resource"])
+          expect_json(errors: ['Resource not found'])
         end
       end
       # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
Motivation:

See the (first bullet in) CHANGELOG for activerecord gem: https://github.com/rails/rails/blob/v8.0.2.1/activerecord/CHANGELOG.md

CVE-2025-55193 Detail

_Active Record connects classes to relational database tables. Prior to versions 7.1.5.2, 7.2.2.2, and 8.0.2.1, the ID passed to find or similar methods may be logged without escaping. If this is directly to the terminal it may include unescaped ANSI sequences. This issue has been patched in versions 7.1.5.2, 7.2.2.2, and 8.0.2.1._


  - In 8.0.2, ActiveRecord raised:
      - raise(... "Couldn't find #{name} with '#{primary_key}'=#{id}")
      - String IDs appeared unquoted (…=wtf).
  - In 8.0.2.1, it switched to:
      - raise(... "Couldn't find #{name} with '#{primary_key}'=#{id.inspect}")
      - String IDs are now quoted (…="wtf"), because inspect adds quotes for strings.


Changes:
  - Standardized 404 errors: Added a global rescue for ActiveRecord::RecordNotFound to return “<Model> not found” (app/api/base.rb)
  - Updated specs to assert on this stable message.




Benefits:
  - Decouples your API from upstream message format changes (like the 8.0.2 → 8.0.2.1 switch to
    id.inspect).
  - Presents consistent, user-friendly errors.