### PR TITLE
(#971) - Trigger validate-graph-resources Argo workflow on S3 upload

### DIFF
--- a/app/services/sync_envelope_graph_with_s3.rb
+++ b/app/services/sync_envelope_graph_with_s3.rb
@@ -57,30 +57,18 @@ class SyncEnvelopeGraphWithS3
   end
 
   def trigger_validate_graph_workflow
-    argo_user = ENV['ARGO_USERNAME'].presence
-    argo_password = ENV['ARGO_PASSWORD'].presence
-    argo_url = ENV['ARGO_SERVER_URL'].presence
-    argo_namespace = ENV['ARGO_NAMESPACE'].presence || 'cer-api'
-    dest_bucket = ENV['ARGO_RESOURCE_BUCKET'].presence || 'cer-resources-prod'
-    return unless argo_user && argo_password && argo_url
+    launcher_url = ENV['WORKFLOW_LAUNCHER_URL'].presence
+    return unless launcher_url
 
     graph_s3_path = "s3://#{s3_bucket_name}/#{s3_key}"
 
-    HTTP.basic_auth(user: argo_user, pass: argo_password)
-        .post(
-          "#{argo_url}/api/v1/workflows/#{argo_namespace}/submit",
-          json: {
-            namespace: argo_namespace,
-            resourceKind: 'WorkflowTemplate',
-            resourceName: 'validate-graph-resources',
-            submitOptions: {
-              parameters: [
-                "graph-s3-path=#{graph_s3_path}",
-                "dest-bucket=#{dest_bucket}"
-              ]
-            }
-          }
-        )
+    HTTP.post(
+      "#{launcher_url}/launch",
+      json: {
+        workflow: 'validateGraphResources',
+        parameters: { graphS3Path: graph_s3_path }
+      }
+    )
   rescue StandardError => e
     MR.logger.error("Failed to trigger validate-graph-resources workflow: #{e.message}")
   end


### PR DESCRIPTION
## Summary

After uploading an envelope graph to S3, automatically triggers the `validate-graph-resources` Argo WorkflowTemplate via the Argo server API.

## Changes

- `app/services/sync_envelope_graph_with_s3.rb` — calls `trigger_validate_graph_workflow` from `upload`, submitting the `validate-graph-resources` WorkflowTemplate with the graph S3 path and destination bucket as parameters

## Configuration

The following env vars are required on the app pods, sourced from the `app-secrets` ExternalSecret (via `credreg-secrets-eks-staging` / `credreg-secrets-eks-production` in AWS Secrets Manager):

| Env var | Description | Default |
|---|---|---|
| `ARGO_SERVER_URL` | Full URL to the Argo server (e.g. `https://argo-cer-api.credentialengineregistry.org`) | required |
| `ARGO_USERNAME` | Basic auth username for Argo server | required |
| `ARGO_PASSWORD` | Basic auth password for Argo server | required |
| `ARGO_NAMESPACE` | Kubernetes namespace where Argo is running | `cer-api` |
| `ARGO_RESOURCE_BUCKET` | Destination bucket for extracted resources | `cer-resources-prod` |

If `ARGO_SERVER_URL`, `ARGO_USERNAME`, or `ARGO_PASSWORD` is not set the call is silently skipped and the upload is unaffected.

Contributes to CredentialEngine/ce-registry#54