### PR TITLE
Protect Redis pod from cluster autoscaler eviction

### DIFF
--- a/terraform/environments/eks/k8s-manifests-prod/redis-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/redis-deployment.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: redis
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       priorityClassName: prod-high
       nodeSelector:

--- a/terraform/environments/eks/k8s-manifests-prod/redis-pdb.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/redis-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redis-pdb
+  namespace: credreg-prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: redis


### PR DESCRIPTION
## Summary
- Add `PodDisruptionBudget` (`redis-pdb`) for the Redis StatefulSet in `credreg-prod` — prevents the cluster autoscaler from evicting the pod when draining nodes
- Add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation to the Redis pod template — explicitly blocks autoscaler-triggered evictions

## Context
A node replacement event at ~05:32 UTC caused the Redis pod to be evicted. The EBS PVC detach/reattach cycle took several minutes, during which all app pods lost their Redis connection and the ingress at credentialengineregistry.org went down. The PDB + annotation together prevent this from happening again.