### PR TITLE
Add production DB table dump workflow via K8s Job

### DIFF
--- a/.github/workflows/db-table-dump.yaml
+++ b/.github/workflows/db-table-dump.yaml
@@ -1,0 +1,111 @@
+name: Production DB table dump
+
+on:
+  workflow_dispatch:
+    inputs:
+      table_name:
+        description: "Table name to dump (e.g. envelopes)"
+        type: string
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  EKS_CLUSTER: ce-registry-eks
+  S3_DUMP_BUCKET: cer-db-dumps-prod
+  PRESIGNED_URL_TTL: 3600
+
+jobs:
+  dump:
+    if: ${{ github.repository_owner == 'CredentialEngine' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/github-oidc-widget
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.29.6
+
+      - name: Update kubeconfig
+        run: aws eks update-kubeconfig --name "${{ env.EKS_CLUSTER }}" --region "${{ env.AWS_REGION }}"
+
+      - name: Validate table name
+        run: |
+          TABLE="${{ inputs.table_name }}"
+          if [[ ! "$TABLE" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+            echo "Invalid table name: '$TABLE'. Only alphanumeric characters and underscores allowed." >&2
+            exit 1
+          fi
+
+      - name: Create dump job
+        id: create_job
+        run: |
+          TABLE="${{ inputs.table_name }}"
+          JOB_NAME=$(
+            sed "s/__TABLE_NAME__/${TABLE}/" \
+              terraform/environments/eks/k8s-manifests-prod/db-table-dump-job.yaml |
+            kubectl -n credreg-prod create -f - -o name | sed 's|job.batch/||'
+          )
+          echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Launched job: ${JOB_NAME}"
+
+      - name: Wait for job completion
+        run: |
+          kubectl -n credreg-prod wait \
+            --for=condition=complete \
+            "job/${{ steps.create_job.outputs.job_name }}" \
+            --timeout=30m
+
+      - name: Get presigned URL
+        id: presign
+        run: |
+          S3_KEY=$(
+            kubectl -n credreg-prod logs "job/${{ steps.create_job.outputs.job_name }}" |
+            grep "^S3_KEY=" | tail -1 | cut -d= -f2-
+          )
+          if [ -z "$S3_KEY" ]; then
+            echo "Could not parse S3_KEY from job logs" >&2
+            exit 1
+          fi
+          PRESIGNED_URL=$(
+            aws s3 presign "s3://${{ env.S3_DUMP_BUCKET }}/${S3_KEY}" \
+              --expires-in "${{ env.PRESIGNED_URL_TTL }}" \
+              --region "${{ env.AWS_REGION }}"
+          )
+          echo "presigned_url=${PRESIGNED_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_WEBHOOK_URL not set; skipping"
+            exit 0
+          fi
+
+          STATUS="${{ job.status }}"
+          TABLE="${{ inputs.table_name }}"
+          ACTOR="${{ github.actor }}"
+
+          if [ "$STATUS" = "success" ]; then
+            PRESIGNED_URL="${{ steps.presign.outputs.presigned_url }}"
+            MSG=":white_check_mark: *DB dump ready* | table: \`${TABLE}\` | triggered by: ${ACTOR}\nDownload (expires in 1h): ${PRESIGNED_URL}\n${RUN_URL}"
+          else
+            MSG=":x: *DB dump failed* | table: \`${TABLE}\` | triggered by: ${ACTOR}\n${RUN_URL}"
+          fi
+
+          payload=$(jq -nc --arg text "$MSG" '{text:$text}')
+          curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" || true

--- a/terraform/environments/eks/k8s-manifests-prod/db-table-dump-job.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/db-table-dump-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: db-table-dump-
+  namespace: credreg-prod
+  labels:
+    app: db-table-dump
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: main-app-service-account
+      restartPolicy: Never
+      containers:
+        - name: pg-dump
+          image: postgres:16-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              apk add --no-cache aws-cli >/dev/null 2>&1
+
+              TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+              DUMP_FILE="/tmp/${TABLE_NAME}_${TIMESTAMP}.dump"
+              S3_KEY="table-dumps/${TABLE_NAME}/${TIMESTAMP}.dump"
+
+              echo "Dumping table '${TABLE_NAME}' from ${POSTGRESQL_DATABASE}..."
+              PGPASSWORD="${POSTGRESQL_PASSWORD}" pg_dump \
+                -h "${POSTGRESQL_ADDRESS}" \
+                -U "${POSTGRESQL_USERNAME}" \
+                -d "${POSTGRESQL_DATABASE}" \
+                -p "${POSTGRESQL_PORT:-5432}" \
+                --table "${TABLE_NAME}" \
+                --no-owner --no-acl \
+                -Fc \
+                -f "${DUMP_FILE}"
+
+              echo "Uploading to s3://${S3_DUMP_BUCKET}/${S3_KEY}"
+              aws s3 cp "${DUMP_FILE}" "s3://${S3_DUMP_BUCKET}/${S3_KEY}" --region us-east-1
+
+              echo "S3_KEY=${S3_KEY}"
+          env:
+            - name: TABLE_NAME
+              value: "__TABLE_NAME__"
+            - name: S3_DUMP_BUCKET
+              value: "cer-db-dumps-prod"
+          envFrom:
+            - secretRef:
+                name: app-secrets

--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -225,6 +225,41 @@ output "cer_envelope_graphs_bucket_name_prod" {
   description = "Production S3 bucket name for envelope graphs"
 }
 
+## DB Dumps S3 bucket
+module "db_dumps_s3" {
+  source          = "../../modules/db_dumps_s3"
+  bucket_name     = "cer-db-dumps-prod"
+  expiration_days = 7
+  common_tags     = local.common_tags
+}
+
+output "db_dumps_bucket_name" {
+  value       = module.db_dumps_s3.bucket_name
+  description = "S3 bucket name for production DB table dumps"
+}
+
+# Allow the GitHub OIDC role to generate presigned URLs for dump objects
+data "aws_iam_role" "github_oidc" {
+  name = "github-oidc-widget"
+}
+
+resource "aws_iam_role_policy" "github_oidc_db_dumps" {
+  name = "db-dumps-presign"
+  role = data.aws_iam_role.github_oidc.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DbDumpsPresign"
+        Effect = "Allow"
+        Action = ["s3:GetObject"]
+        Resource = "${module.db_dumps_s3.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
 ## CloudWatch Log Forwarding to Slack
 module "cloudwatch_slack_forwarder" {
   source            = "../../modules/cloudwatch_slack_forwarder"

--- a/terraform/modules/db_dumps_s3/main.tf
+++ b/terraform/modules/db_dumps_s3/main.tf
@@ -1,0 +1,52 @@
+locals {
+  tags = merge(var.common_tags, {
+    Name    = var.bucket_name
+    purpose = "db-table-dumps"
+  })
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-dumps"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+}

--- a/terraform/modules/db_dumps_s3/outputs.tf
+++ b/terraform/modules/db_dumps_s3/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  value       = aws_s3_bucket.this.bucket
+  description = "S3 bucket name for DB dumps"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.this.arn
+  description = "S3 bucket ARN for DB dumps"
+}

--- a/terraform/modules/db_dumps_s3/variables.tf
+++ b/terraform/modules/db_dumps_s3/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for DB dumps"
+  type        = string
+}
+
+variable "expiration_days" {
+  description = "Number of days after which dump objects are automatically deleted"
+  type        = number
+  default     = 7
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/eks/irsa-iam-policy-and-role.tf
+++ b/terraform/modules/eks/irsa-iam-policy-and-role.tf
@@ -127,7 +127,8 @@ resource "aws_iam_policy" "application_policy" {
           "arn:aws:s3:::cer-envelope-graphs-prod-us-east-1/*",
           "arn:aws:s3:::cer-envelope-downloads/*",
           "arn:aws:s3:::ocn-exports/*",
-          "arn:aws:s3:::cer-resources*/*"
+          "arn:aws:s3:::cer-resources*/*",
+          "arn:aws:s3:::cer-db-dumps-prod/*"
         ]
       },
       {
@@ -147,7 +148,8 @@ resource "aws_iam_policy" "application_policy" {
           "arn:aws:s3:::cer-envelope-graphs-prod-us-east-1",
           "arn:aws:s3:::cer-envelope-downloads",
           "arn:aws:s3:::ocn-exports",
-          "arn:aws:s3:::cer-resources*"
+          "arn:aws:s3:::cer-resources*",
+          "arn:aws:s3:::cer-db-dumps-prod"
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- Manually-triggered GH Actions workflow (`workflow_dispatch`) that accepts a table name, spins up a K8s Job in `credreg-prod`, runs `pg_dump`, uploads to a private S3 bucket, and posts a 1-hour presigned download URL to Slack
- New Terraform module `db_dumps_s3` provisions `cer-db-dumps-prod` (private, AES-256 encrypted, 7-day auto-expiry) — already applied
- IRSA `application_policy` extended with `s3:PutObject` on the dump bucket; `github-oidc-widget` gets `s3:GetObject` for presign generation — already applied
- K8s Job uses existing `app-secrets` for DB credentials (`POSTGRESQL_*` env vars) and `main-app-service-account` IRSA for S3 access