### PR TITLE
Retarget feature-branch deploy workflow at credreg-test

### DIFF
--- a/.github/workflows/deploy-feature-to-staging.yaml
+++ b/.github/workflows/deploy-feature-to-staging.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: registry
-  EKS_CLUSTER: ce-registry-eks
+  EKS_CLUSTER: cer-api-prod
 
 jobs:
   build-and-deploy:
@@ -71,24 +71,24 @@ jobs:
         run: |
           aws eks update-kubeconfig --name "${{ env.EKS_CLUSTER }}" --region "${{ env.AWS_REGION }}"
 
-      - name: Deploy to credreg-staging (set images)
+      - name: Deploy to credreg-test (set images)
         env:
           IMAGE: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.ref_tag }}
         run: |
-          NS=credreg-staging
+          NS=credreg-test
           echo "Updating deployments in $NS to image $IMAGE"
           kubectl -n "$NS" set image deploy/main-app   main-app="$IMAGE"
           kubectl -n "$NS" set image deploy/worker-app worker="$IMAGE"
           kubectl -n "$NS" rollout status deploy/main-app --timeout=10m
           kubectl -n "$NS" rollout status deploy/worker-app --timeout=10m
 
-      - name: Run DB migrations (staging)
+      - name: Run DB migrations (test)
         env:
           IMAGE: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.ref_tag }}
         run: |
           set -euo pipefail
-          NS="credreg-staging"
-          MANIFEST="terraform/environments/eks/k8s-manifests-staging/db-migrate-job.yaml"
+          NS="credreg-test"
+          MANIFEST="terraform/environments/eks/k8s-manifests-test/db-migrate-job.yaml"
 
           if [ ! -f "$MANIFEST" ]; then
             echo "Migration manifest $MANIFEST not found; skipping"
@@ -120,7 +120,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          ENVIRONMENT: staging
+          ENVIRONMENT: test
           BRANCH: ${{ inputs.branch }}
           IMAGE: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.ref_tag }}
         run: |

--- a/terraform/environments/eks/k8s-manifests-test/db-migrate-job.yaml
+++ b/terraform/environments/eks/k8s-manifests-test/db-migrate-job.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: db-migrate-
+  namespace: credreg-test
+  labels:
+    app: main-app
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 900
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: main-app
+    spec:
+      priorityClassName: test-normal
+      nodeSelector:
+        env: test
+      tolerations:
+        - key: "env"
+          operator: "Equal"
+          value: "test"
+          effect: "NoSchedule"
+      serviceAccountName: main-app-service-account
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:master
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-lc", "bundle exec rake db:create db:migrate RACK_ENV=staging"]
+          envFrom:
+            - secretRef:
+                name: app-secrets
+            - configMapRef:
+                name: main-app-config


### PR DESCRIPTION
## Summary
- The staging env was renamed to `credreg-test` and moved to the `cer-api-prod` EKS cluster. `deploy-feature-to-staging.yaml` was still targeting `ce-registry-eks` / `credreg-staging`, so the DB-migration step timed out (run [24905871968](https://github.com/CredentialEngine/CredentialRegistry/actions/runs/24905871968)).
- Point the workflow at `cer-api-prod` / `credreg-test`, switch the Slack `ENVIRONMENT` label to `test`.
- Add `terraform/environments/eks/k8s-manifests-test/db-migrate-job.yaml` (copy of the version in the `ce-registry` repo) so the migration job schedules on the test node group (`nodeSelector env=test`, toleration, `priorityClassName: test-normal`).

## Test plan
- [ ] Trigger `Deploy feature branch to staging environment` via workflow_dispatch on a test branch
- [ ] Verify `set image` + `rollout status` succeed against `deploy/main-app` and `deploy/worker-app` in `credreg-test`
- [ ] Verify the `db-migrate-*` Job in `credreg-test` schedules on a test node, runs `rake db:create db:migrate`, and reaches `Complete`
- [ ] Confirm Slack notification shows `env: test`

## Notes
- Assumes the `github-oidc-widget` IAM role already has an EKS access entry on `cer-api-prod`. If the `aws eks update-kubeconfig` / first kubectl call fails with an auth error, add the access entry.
- The migration manifest now lives in both repos (`CredentialRegistry` and `ce-registry/infra`). Worth consolidating later.