### PR TITLE
Add k8s auth for Argo calls

### DIFF
--- a/app/services/argo_workflows_client.rb
+++ b/app/services/argo_workflows_client.rb
@@ -1,14 +1,16 @@
 require 'argo_workflows_api_client'
 require 'base64'
+require 'kubernetes_service_account_token_requester'
 require 'uri'
 
 class ArgoWorkflowsClient
   attr_reader :namespace
 
-  def initialize(configuration: build_configuration)
-    @namespace = ENV.fetch('ARGO_WORKFLOWS_NAMESPACE')
+  def initialize(configuration: nil)
+    configuration ||= build_configuration
+    @namespace = configuration.fetch(:namespace)
     @workflow_service_api = ArgoWorkflowsApiClient::WorkflowServiceApi.new(
-      ArgoWorkflowsApiClient::ApiClient.new(configuration)
+      ArgoWorkflowsApiClient::ApiClient.new(configuration.fetch(:client_configuration))
     )
   end
 
@@ -40,26 +42,32 @@ class ArgoWorkflowsClient
 
   def build_configuration
     base_uri = URI.parse(ENV.fetch('ARGO_WORKFLOWS_BASE_URL'))
+    namespace = ENV.fetch('ARGO_WORKFLOWS_NAMESPACE')
 
-    ArgoWorkflowsApiClient::Configuration.new.tap do |config|
+    client_configuration = ArgoWorkflowsApiClient::Configuration.new.tap do |config|
       config.scheme = base_uri.scheme
       config.host = [base_uri.host, base_uri.port].compact.join(':')
       config.base_path = base_uri.path
-      configure_auth(config)
+      configure_auth(config, namespace:)
       config.timeout = ENV.fetch('ARGO_WORKFLOWS_TIMEOUT_SECONDS', 30).to_i
 
       # The in-cluster Argo endpoint uses a self-signed certificate.
       config.verify_ssl = false
       config.verify_ssl_host = false
     end
+
+    { namespace:, client_configuration: }
   end
 
   def workflow_service_api
     @workflow_service_api
   end
 
-  def configure_auth(config)
-    if env_present?('ARGO_WORKFLOWS_USERNAME', 'ARGO_WORKFLOWS_PASSWORD')
+  def configure_auth(config, namespace:)
+    if env_present?('ARGO_WORKFLOWS_K8S_API_URL', 'ARGO_WORKFLOWS_K8S_CLUSTER_NAME', 'ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT')
+      config.api_key['Authorization'] = kubernetes_service_account_token_requester(namespace:)
+      config.api_key_prefix['Authorization'] = 'Bearer'
+    elsif env_present?('ARGO_WORKFLOWS_USERNAME', 'ARGO_WORKFLOWS_PASSWORD')
       config.api_key['Authorization'] = basic_auth_token
       config.api_key_prefix['Authorization'] = 'Basic'
     else
@@ -74,5 +82,16 @@ class ArgoWorkflowsClient
 
   def basic_auth_token
     Base64.strict_encode64("#{ENV.fetch('ARGO_WORKFLOWS_USERNAME')}:#{ENV.fetch('ARGO_WORKFLOWS_PASSWORD')}")
+  end
+
+  def kubernetes_service_account_token_requester(namespace:)
+    KubernetesServiceAccountTokenRequester.new(
+      api_url: ENV.fetch('ARGO_WORKFLOWS_K8S_API_URL'),
+      cluster_name: ENV.fetch('ARGO_WORKFLOWS_K8S_CLUSTER_NAME'),
+      namespace: ENV.fetch('ARGO_WORKFLOWS_K8S_NAMESPACE', namespace),
+      service_account: ENV.fetch('ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT'),
+      audience: ENV.fetch('ARGO_WORKFLOWS_K8S_TOKEN_AUDIENCE', 'https://kubernetes.default.svc'),
+      expiration_seconds: ENV.fetch('ARGO_WORKFLOWS_K8S_TOKEN_EXPIRATION_SECONDS', 600)
+    )
   end
 end

--- a/app/services/kubernetes_service_account_token_requester.rb
+++ b/app/services/kubernetes_service_account_token_requester.rb
@@ -76,7 +76,6 @@ class KubernetesServiceAccountTokenRequester
   def http
     Net::HTTP.new(token_request_uri.host, token_request_uri.port).tap do |http|
       http.use_ssl = token_request_uri.scheme == 'https'
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
   end
 

--- a/app/services/kubernetes_service_account_token_requester.rb
+++ b/app/services/kubernetes_service_account_token_requester.rb
@@ -1,0 +1,129 @@
+require 'aws-sdk-core'
+require 'aws-sigv4'
+require 'base64'
+require 'json'
+require 'net/http'
+require 'openssl'
+require 'time'
+require 'uri'
+
+class KubernetesServiceAccountTokenRequester
+  TOKEN_REFRESH_SKEW_SECONDS = 60
+
+  def initialize(
+    api_url:,
+    cluster_name:,
+    namespace:,
+    service_account:,
+    audience: 'https://kubernetes.default.svc',
+    expiration_seconds: 600,
+    region: ENV.fetch('AWS_REGION', 'us-east-1'),
+    credentials_provider: Aws::CredentialProviderChain.new.resolve
+  )
+    @api_url = api_url
+    @cluster_name = cluster_name
+    @namespace = namespace
+    @service_account = service_account
+    @audience = audience
+    @expiration_seconds = expiration_seconds.to_i
+    @region = region
+    @credentials_provider = credentials_provider
+    @token = nil
+    @expires_at = nil
+  end
+
+  def token
+    return @token if @token && @expires_at && Time.now < @expires_at - TOKEN_REFRESH_SKEW_SECONDS
+
+    refresh_token
+  end
+
+  def to_s
+    token
+  end
+
+  private
+
+  def refresh_token
+    response = http.request(request)
+    parsed_body = parse_body(response.body)
+
+    unless response.code.to_i.between?(200, 299)
+      raise "Kubernetes token request failed: HTTP #{response.code} #{response.message} #{response.body}"
+    end
+
+    @token = parsed_body.fetch('status').fetch('token')
+    @expires_at = parse_expiration(parsed_body.dig('status', 'expirationTimestamp'))
+    @token
+  end
+
+  def request
+    Net::HTTP::Post.new(token_request_uri).tap do |request|
+      request['Authorization'] = "Bearer #{eks_bearer_token}"
+      request['Content-Type'] = 'application/json'
+      request['Accept'] = 'application/json'
+      request.body = JSON.generate(
+        apiVersion: 'authentication.k8s.io/v1',
+        kind: 'TokenRequest',
+        spec: {
+          audiences: [@audience],
+          expirationSeconds: @expiration_seconds
+        }
+      )
+    end
+  end
+
+  def http
+    Net::HTTP.new(token_request_uri.host, token_request_uri.port).tap do |http|
+      http.use_ssl = token_request_uri.scheme == 'https'
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+  end
+
+  def token_request_uri
+    @token_request_uri ||= begin
+      base_uri = URI.parse(@api_url)
+      base_path = base_uri.path.to_s.sub(%r{/+\z}, '')
+      base_uri.path = "#{base_path}/api/v1/namespaces/#{@namespace}/serviceaccounts/#{@service_account}/token"
+      base_uri.query = nil
+      base_uri
+    end
+  end
+
+  def eks_bearer_token
+    presigned_url = sts_signer.presign_url(
+      http_method: 'GET',
+      url: sts_url,
+      headers: {
+        'x-k8s-aws-id' => @cluster_name
+      },
+      expires_in: 60
+    ).to_s
+
+    "k8s-aws-v1.#{Base64.urlsafe_encode64(presigned_url).delete('=')}"
+  end
+
+  def sts_signer
+    @sts_signer ||= Aws::Sigv4::Signer.new(
+      service: 'sts',
+      region: @region,
+      credentials_provider: @credentials_provider
+    )
+  end
+
+  def sts_url
+    "https://sts.#{@region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+  end
+
+  def parse_body(body)
+    JSON.parse(body)
+  rescue JSON::ParserError
+    raise "Kubernetes token request returned non-JSON response: #{body}"
+  end
+
+  def parse_expiration(expiration_timestamp)
+    return Time.now + @expiration_seconds unless expiration_timestamp
+
+    Time.parse(expiration_timestamp)
+  end
+end

--- a/docs/11_registry_changeset_sync.md
+++ b/docs/11_registry_changeset_sync.md
@@ -373,9 +373,15 @@ key, workflow name, and namespace.
 
 Authentication preference is:
 
-1. Basic auth when `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD` are
+1. Short-lived Kubernetes service account token when
+   `ARGO_WORKFLOWS_K8S_API_URL`, `ARGO_WORKFLOWS_K8S_CLUSTER_NAME`, and
+   `ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT` are present.
+2. Basic auth when `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD` are
    present.
-2. Bearer auth from `ARGO_WORKFLOWS_TOKEN`.
+3. Bearer auth from `ARGO_WORKFLOWS_TOKEN`.
+
+See `docs/12_argo_auth.md` for the Kubernetes token request flow, required
+target-cluster IAM/RBAC setup, and troubleshooting notes.
 
 SSL verification is disabled in the client because the app runs inside a trusted
 environment.
@@ -528,14 +534,19 @@ Required environment for S3/Argo sync:
 - `ARGO_WORKFLOWS_BASE_URL`
 - `ARGO_WORKFLOWS_NAMESPACE`
 - `ARGO_WORKFLOWS_TASK_IMAGE`
-- either `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD`, or
-  `ARGO_WORKFLOWS_TOKEN`
+- one supported Argo auth mode. See `docs/12_argo_auth.md`.
 
 Useful optional environment:
 
 - `REGISTRY_CHANGESET_SYNC_DEBOUNCE_SECONDS`
 - `REGISTRY_CHANGESET_SYNC_LOCK_TIMEOUT_SECONDS`
 - `ARGO_WORKFLOWS_TIMEOUT_SECONDS`
+- `ARGO_WORKFLOWS_K8S_API_URL`
+- `ARGO_WORKFLOWS_K8S_CLUSTER_NAME`
+- `ARGO_WORKFLOWS_K8S_NAMESPACE`
+- `ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT`
+- `ARGO_WORKFLOWS_K8S_TOKEN_AUDIENCE`
+- `ARGO_WORKFLOWS_K8S_TOKEN_EXPIRATION_SECONDS`
 - `ELASTICSEARCH_URL`
 - `ELASTICSEARCH_USERNAME`
 - `ELASTICSEARCH_PASSWORD`

--- a/docs/12_argo_auth.md
+++ b/docs/12_argo_auth.md
@@ -1,0 +1,102 @@
+# Argo Authentication
+
+The registry talks to Argo through `ArgoWorkflowsClient`. The client supports
+three authentication modes so existing deployments can keep their current setup
+while EKS-to-EKS deployments can use short-lived Kubernetes service account
+tokens.
+
+## Required Argo Settings
+
+All modes require:
+
+- `ARGO_WORKFLOWS_BASE_URL`: Argo Workflows API base URL.
+- `ARGO_WORKFLOWS_NAMESPACE`: Argo workflow namespace used for submit/get calls.
+- `ARGO_WORKFLOWS_TIMEOUT_SECONDS`: optional request timeout, defaulting to `30`.
+
+SSL verification is disabled in the generated Argo API client because the
+service is expected to call an internal, trusted Argo endpoint.
+
+## Authentication Precedence
+
+`ArgoWorkflowsClient` chooses authentication in this order:
+
+1. Short-lived Kubernetes service account token when all of these are present:
+   - `ARGO_WORKFLOWS_K8S_API_URL`
+   - `ARGO_WORKFLOWS_K8S_CLUSTER_NAME`
+   - `ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT`
+2. Basic auth when both of these are present:
+   - `ARGO_WORKFLOWS_USERNAME`
+   - `ARGO_WORKFLOWS_PASSWORD`
+3. Static bearer token:
+   - `ARGO_WORKFLOWS_TOKEN`
+
+The Kubernetes token mode intentionally wins over Basic/static bearer auth. This
+allows deployments to leave older secrets configured during rollout while the
+new token flow takes effect as soon as its required variables are present.
+
+## Short-Lived Kubernetes Token Mode
+
+Use this mode when the registry app runs in one EKS cluster and needs to call
+Argo in another EKS cluster using IAM auth. The app uses its AWS credentials
+from IRSA to create an EKS IAM authenticator token, calls the target Kubernetes
+`TokenRequest` endpoint, and uses the returned short-lived service account token
+as the Argo bearer token.
+
+Required variables:
+
+- `ARGO_WORKFLOWS_K8S_API_URL`: Kubernetes API server URL for the cluster that
+  hosts Argo.
+- `ARGO_WORKFLOWS_K8S_CLUSTER_NAME`: exact EKS cluster name for the target
+  cluster. This value is used as the `x-k8s-aws-id` signing header and must
+  match the cluster name exactly.
+- `ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT`: service account to request a token for,
+  for example `credreg-app`.
+
+Optional variables:
+
+- `ARGO_WORKFLOWS_K8S_NAMESPACE`: namespace of the service account token to
+  request. Defaults to `ARGO_WORKFLOWS_NAMESPACE`.
+- `ARGO_WORKFLOWS_K8S_TOKEN_AUDIENCE`: token audience, defaulting to
+  `https://kubernetes.default.svc`.
+- `ARGO_WORKFLOWS_K8S_TOKEN_EXPIRATION_SECONDS`: requested token lifetime,
+  defaulting to `600`.
+
+The app caches the returned Kubernetes token and refreshes it shortly before
+expiration. It does not persist the token.
+
+## Target Cluster Access
+
+The IAM role used by the registry pod must be accepted by the target EKS
+cluster. In an IRSA deployment, this is the role annotated on the registry app
+service account.
+
+The target cluster must map that IAM role to a Kubernetes user/group that is
+authorized to create service account tokens only for the intended Argo-facing
+service account. The Kubernetes permission is a `create` on the `serviceaccounts/token`
+subresource for the target namespace/service account.
+
+Example target:
+
+- namespace: `cer-api-sandbox`
+- service account: `credreg-app`
+- Kubernetes group: `credreg-app-token-requesters`
+
+With that setup, the registry role can request a short-lived token for
+`cer-api-sandbox/credreg-app`, and Argo receives that token in the normal
+`Authorization: Bearer ...` header.
+
+## Troubleshooting
+
+- `401 Unauthorized` from the Kubernetes `TokenRequest` call usually means the
+  target EKS cluster rejected the IAM authenticator token. Check
+  `ARGO_WORKFLOWS_K8S_CLUSTER_NAME`, the target cluster IAM access mapping, and
+  that the pod is actually assuming the expected IRSA role.
+- `403 Forbidden` usually means IAM authentication succeeded, but Kubernetes
+  RBAC does not allow the mapped user/group to create the requested service
+  account token.
+- `404 Not Found` usually means the namespace or service account name is wrong,
+  or the target cluster URL is not the cluster that contains that service
+  account.
+- If Argo itself returns authorization errors after a token is successfully
+  requested, check the permissions bound to the target service account that Argo
+  uses for API authorization.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,17 +18,55 @@ docker compose -f docker-compose.test.yml \
   up --abort-on-container-exit --exit-code-from app
 ```
 
-In this repo, the app reads database settings from `POSTGRESQL_*` variables,
-not only `DATABASE_URL`. If the compose test stack fails to resolve or connect
-to Postgres, run the suite with explicit database overrides:
+In this repo, the app can read database settings from both `DATABASE_URL` and
+`POSTGRESQL_*` variables. If the compose test stack fails to resolve or connect
+to Postgres, run the suite with explicit database overrides for both forms:
 
 ```sh
 docker compose -f docker-compose.test.yml run --rm \
+  -e DATABASE_URL=postgresql://postgres:postgres@postgres:5432/metadataregistry_test \
   -e POSTGRESQL_ADDRESS=postgres \
   -e POSTGRESQL_USERNAME=postgres \
   -e POSTGRESQL_PASSWORD=postgres \
   -e POSTGRESQL_DATABASE=metadataregistry_test \
   app
+```
+
+If the database does not exist in a fresh test stack, create and migrate it
+with the same overrides before running specs:
+
+```sh
+docker compose -f docker-compose.test.yml run --rm \
+  -e DATABASE_URL=postgresql://postgres:postgres@postgres:5432/metadataregistry_test \
+  -e POSTGRESQL_ADDRESS=postgres \
+  -e POSTGRESQL_USERNAME=postgres \
+  -e POSTGRESQL_PASSWORD=postgres \
+  -e POSTGRESQL_DATABASE=metadataregistry_test \
+  app bin/rake db:create db:migrate
+```
+
+If the existing test image is stale and Bundler reports missing locked gems,
+install the bundle into a temporary host-mounted directory and reuse it for the
+test run:
+
+```sh
+mkdir -p /private/tmp/credentialregistry-test-bundle
+
+docker compose -f docker-compose.test.yml run --rm --entrypoint bundle \
+  -e BUNDLE_PATH=/bundle \
+  -e BUNDLE_WITH="development test" \
+  -v /private/tmp/credentialregistry-test-bundle:/bundle \
+  app install --jobs 4 --retry 3
+
+docker compose -f docker-compose.test.yml run --rm --entrypoint bundle \
+  -e BUNDLE_PATH=/bundle \
+  -e DATABASE_URL=postgresql://postgres:postgres@postgres:5432/metadataregistry_test \
+  -e POSTGRESQL_ADDRESS=postgres \
+  -e POSTGRESQL_USERNAME=postgres \
+  -e POSTGRESQL_PASSWORD=postgres \
+  -e POSTGRESQL_DATABASE=metadataregistry_test \
+  -v /private/tmp/credentialregistry-test-bundle:/bundle \
+  app exec rspec
 ```
 
 After a test run, clean up the test stack:

--- a/spec/services/argo_workflows_client_spec.rb
+++ b/spec/services/argo_workflows_client_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 RSpec.describe ArgoWorkflowsClient do
   let(:api_client) { instance_double(ArgoWorkflowsApiClient::ApiClient) }
   let(:workflow_service_api) { instance_double(ArgoWorkflowsApiClient::WorkflowServiceApi) }
-  let(:configuration) { instance_double(ArgoWorkflowsApiClient::Configuration) }
+  let(:client_configuration) { instance_double(ArgoWorkflowsApiClient::Configuration) }
+  let(:configuration) { { namespace: 'credreg-staging', client_configuration: } }
   let(:workflow) { { metadata: { name: 'ce-registry-download-abc123' } } }
 
   before do
@@ -13,12 +14,15 @@ RSpec.describe ArgoWorkflowsClient do
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN').and_return('static-argo-token')
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_USERNAME', nil).and_return(nil)
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_PASSWORD', nil).and_return(nil)
+    allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_API_URL', nil).and_return(nil)
+    allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_CLUSTER_NAME', nil).and_return(nil)
+    allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT', nil).and_return(nil)
     unless configuration.nil?
-      allow(api_client).to receive(:config).and_return(configuration)
-      allow(configuration).to receive(:api_key).and_return({})
-      allow(configuration).to receive(:api_key_prefix).and_return({})
+      allow(api_client).to receive(:config).and_return(client_configuration)
+      allow(client_configuration).to receive(:api_key).and_return({})
+      allow(client_configuration).to receive(:api_key_prefix).and_return({})
     end
-    allow(ArgoWorkflowsApiClient::ApiClient).to receive(:new).with(configuration).and_return(api_client)
+    allow(ArgoWorkflowsApiClient::ApiClient).to receive(:new).with(client_configuration).and_return(api_client)
     allow(ArgoWorkflowsApiClient::WorkflowServiceApi)
       .to receive(:new).with(api_client).and_return(workflow_service_api)
     allow(workflow_service_api).to receive(:api_client).and_return(api_client)
@@ -65,6 +69,9 @@ RSpec.describe ArgoWorkflowsClient do
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TIMEOUT_SECONDS', 30).and_return(30)
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_USERNAME', nil).and_return(nil)
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_PASSWORD', nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_API_URL', nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_CLUSTER_NAME', nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT', nil).and_return(nil)
       allow(ArgoWorkflowsApiClient::Configuration).to receive(:new).and_return(built_configuration)
       allow(ArgoWorkflowsApiClient::ApiClient).to receive(:new).with(built_configuration).and_return(api_client)
       allow(api_client).to receive(:config).and_return(built_configuration)
@@ -94,6 +101,36 @@ RSpec.describe ArgoWorkflowsClient do
 
       expect(built_configuration.api_key['Authorization']).to eq(Base64.strict_encode64('argo-user:argo-password'))
       expect(built_configuration.api_key_prefix['Authorization']).to eq('Basic')
+    end
+
+    it 'uses a requested Kubernetes service account token when Kubernetes token auth is configured' do
+      token_requester = instance_double(KubernetesServiceAccountTokenRequester)
+
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_API_URL', nil).and_return('https://k8s.example.test')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_CLUSTER_NAME', nil).and_return('cer-api-sandbox')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT', nil).and_return('credreg-app')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_API_URL').and_return('https://k8s.example.test')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_CLUSTER_NAME').and_return('cer-api-sandbox')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_SERVICE_ACCOUNT').and_return('credreg-app')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_NAMESPACE', 'credreg-staging').and_return('cer-api-sandbox')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_TOKEN_AUDIENCE', 'https://kubernetes.default.svc').and_return('https://kubernetes.default.svc')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_K8S_TOKEN_EXPIRATION_SECONDS', 600).and_return('600')
+      allow(KubernetesServiceAccountTokenRequester).to receive(:new)
+        .with(
+          api_url: 'https://k8s.example.test',
+          cluster_name: 'cer-api-sandbox',
+          namespace: 'cer-api-sandbox',
+          service_account: 'credreg-app',
+          audience: 'https://kubernetes.default.svc',
+          expiration_seconds: '600'
+        ).and_return(token_requester)
+
+      allow(workflow_service_api).to receive(:workflow_service_get_workflow).and_return(workflow)
+
+      described_class.new.get_workflow(name: 'ce-registry-download-abc123')
+
+      expect(built_configuration.api_key['Authorization']).to eq(token_requester)
+      expect(built_configuration.api_key_prefix['Authorization']).to eq('Bearer')
     end
 
     it 'disables SSL verification for the in-cluster Argo endpoint' do

--- a/spec/services/kubernetes_service_account_token_requester_spec.rb
+++ b/spec/services/kubernetes_service_account_token_requester_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe KubernetesServiceAccountTokenRequester do
+  let(:credentials_provider) { instance_double(Aws::Credentials) }
+  let(:signer) { instance_double(Aws::Sigv4::Signer) }
+  let(:presigned_url) do
+    URI('https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15&X-Amz-SignedHeaders=host%3Bx-k8s-aws-id')
+  end
+  let(:token_request_body) do
+    {
+      kind: 'TokenRequest',
+      apiVersion: 'authentication.k8s.io/v1',
+      status: {
+        token: 'short-lived-k8s-token',
+        expirationTimestamp: 10.minutes.from_now.iso8601
+      }
+    }
+  end
+
+  subject(:requester) do
+    described_class.new(
+      api_url: 'https://k8s.example.test',
+      cluster_name: 'cer-api-sandbox',
+      namespace: 'cer-api-sandbox',
+      service_account: 'credreg-app',
+      audience: 'https://kubernetes.default.svc',
+      expiration_seconds: 600,
+      region: 'us-east-1',
+      credentials_provider:
+    )
+  end
+
+  before do
+    allow(Aws::Sigv4::Signer).to receive(:new)
+      .with(service: 'sts', region: 'us-east-1', credentials_provider:)
+      .and_return(signer)
+    allow(signer).to receive(:presign_url)
+      .with(
+        http_method: 'GET',
+        url: 'https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
+        headers: { 'x-k8s-aws-id' => 'cer-api-sandbox' },
+        expires_in: 60
+      ).and_return(presigned_url)
+
+    stub_request(:post, 'https://k8s.example.test/api/v1/namespaces/cer-api-sandbox/serviceaccounts/credreg-app/token')
+      .with(
+        headers: {
+          'Accept' => 'application/json',
+          'Authorization' => /^Bearer k8s-aws-v1\./,
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          apiVersion: 'authentication.k8s.io/v1',
+          kind: 'TokenRequest',
+          spec: {
+            audiences: ['https://kubernetes.default.svc'],
+            expirationSeconds: 600
+          }
+        }.to_json
+      )
+      .to_return(status: 201, body: token_request_body.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  it 'requests and returns a short-lived Kubernetes service account token' do
+    expect(requester.token).to eq('short-lived-k8s-token')
+  end
+
+  it 'reuses the token while it is not near expiration' do
+    requester.token
+    requester.token
+
+    expect(WebMock).to have_requested(
+      :post,
+      'https://k8s.example.test/api/v1/namespaces/cer-api-sandbox/serviceaccounts/credreg-app/token'
+    ).once
+  end
+end


### PR DESCRIPTION
Implement Argo auth via short-lived Kubernetes service account tokens.

Adds an opt-in EKS IAM auth flow that requests a Kubernetes TokenRequest token when ARGO_WORKFLOWS_K8S_* env vars are configured.