### PR TITLE
Read K8s service account token from mounted file

### DIFF
--- a/app/services/argo_workflows_client.rb
+++ b/app/services/argo_workflows_client.rb
@@ -59,7 +59,10 @@ class ArgoWorkflowsClient
   end
 
   def configure_auth(config)
-    if env_present?('ARGO_WORKFLOWS_USERNAME', 'ARGO_WORKFLOWS_PASSWORD')
+    if env_present?('ARGO_WORKFLOWS_TOKEN_PATH')
+      config.api_key['Authorization'] = projected_service_account_token
+      config.api_key_prefix['Authorization'] = 'Bearer'
+    elsif env_present?('ARGO_WORKFLOWS_USERNAME', 'ARGO_WORKFLOWS_PASSWORD')
       config.api_key['Authorization'] = basic_auth_token
       config.api_key_prefix['Authorization'] = 'Basic'
     else
@@ -74,5 +77,9 @@ class ArgoWorkflowsClient
 
   def basic_auth_token
     Base64.strict_encode64("#{ENV.fetch('ARGO_WORKFLOWS_USERNAME')}:#{ENV.fetch('ARGO_WORKFLOWS_PASSWORD')}")
+  end
+
+  def projected_service_account_token
+    File.read(ENV.fetch('ARGO_WORKFLOWS_TOKEN_PATH')).strip
   end
 end

--- a/docs/11_registry_changeset_sync.md
+++ b/docs/11_registry_changeset_sync.md
@@ -373,9 +373,11 @@ key, workflow name, and namespace.
 
 Authentication preference is:
 
-1. Basic auth when `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD` are
+1. Bearer auth from a projected service account token file when
+   `ARGO_WORKFLOWS_TOKEN_PATH` is present.
+2. Basic auth when `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD` are
    present.
-2. Bearer auth from `ARGO_WORKFLOWS_TOKEN`.
+3. Bearer auth from `ARGO_WORKFLOWS_TOKEN`.
 
 SSL verification is disabled in the client because the app runs inside a trusted
 environment.
@@ -528,8 +530,8 @@ Required environment for S3/Argo sync:
 - `ARGO_WORKFLOWS_BASE_URL`
 - `ARGO_WORKFLOWS_NAMESPACE`
 - `ARGO_WORKFLOWS_TASK_IMAGE`
-- either `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD`, or
-  `ARGO_WORKFLOWS_TOKEN`
+- `ARGO_WORKFLOWS_TOKEN_PATH`, `ARGO_WORKFLOWS_TOKEN`, or
+  `ARGO_WORKFLOWS_USERNAME` and `ARGO_WORKFLOWS_PASSWORD`
 
 Useful optional environment:
 

--- a/spec/services/argo_workflows_client_spec.rb
+++ b/spec/services/argo_workflows_client_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ArgoWorkflowsClient do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_NAMESPACE').and_return('credreg-staging')
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN').and_return('static-argo-token')
+    allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN_PATH', nil).and_return(nil)
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_USERNAME', nil).and_return(nil)
     allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_PASSWORD', nil).and_return(nil)
     unless configuration.nil?
@@ -65,9 +66,23 @@ RSpec.describe ArgoWorkflowsClient do
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TIMEOUT_SECONDS', 30).and_return(30)
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_USERNAME', nil).and_return(nil)
       allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_PASSWORD', nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN_PATH', nil).and_return(nil)
       allow(ArgoWorkflowsApiClient::Configuration).to receive(:new).and_return(built_configuration)
       allow(ArgoWorkflowsApiClient::ApiClient).to receive(:new).with(built_configuration).and_return(api_client)
       allow(api_client).to receive(:config).and_return(built_configuration)
+    end
+
+    it 'uses a projected service account token when ARGO_WORKFLOWS_TOKEN_PATH is configured' do
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN_PATH', nil).and_return('/var/run/secrets/tokens/argo')
+      allow(ENV).to receive(:fetch).with('ARGO_WORKFLOWS_TOKEN_PATH').and_return('/var/run/secrets/tokens/argo')
+      allow(File).to receive(:read).with('/var/run/secrets/tokens/argo').and_return("projected-argo-token\n")
+
+      allow(workflow_service_api).to receive(:workflow_service_get_workflow).and_return(workflow)
+
+      described_class.new.get_workflow(name: 'ce-registry-download-abc123')
+
+      expect(built_configuration.api_key['Authorization']).to eq('projected-argo-token')
+      expect(built_configuration.api_key_prefix['Authorization']).to eq('Bearer')
     end
 
     it 'uses ARGO_WORKFLOWS_TOKEN when Basic auth is not configured' do


### PR DESCRIPTION
Read the token used for Argo auth from `ARGO_WORKFLOWS_TOKEN_PATH` when the env var is available.

K8s will mount the file (see [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection)) and set the env var for the pod.