### PR TITLE
Reduce New Relic ingest volume

### DIFF
--- a/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
@@ -12,5 +12,6 @@ data:
   ENVELOPE_DOWNLOADS_BUCKET: cer-envelope-downloads
   AIRBRAKE_PROJECT_ID: '270205'
   SIDEKIQ_CONCURRENCY: '10'
+  LOG_LEVEL: "WARN"
   API_KEY_VALIDATION_ENDPOINT: https://apps.credentialengine.org/accountsAPI/Organization/ValidateApiKey
   ELASTICSEARCH_ADDRESS: http://elasticsearch:9200

--- a/terraform/environments/eks/k8s-manifests-sandbox/app-configmap.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/app-configmap.yaml
@@ -18,5 +18,10 @@ data:
   IAM_URL: https://login.sandbox.credentialengine.org/realms/CE-Sandbox
   AIRBRAKE_PROJECT_ID: '270205'
   SIDEKIQ_CONCURRENCY: '10'
+  LOG_LEVEL: "WARN"
+  SWAGGER_ENABLED: "true"
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED: "false"
+  NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED: "500"
+  NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED: "300"
   API_KEY_VALIDATION_ENDPOINT: https://sandbox.credentialengine.org/accountsAPI/Organization/ValidateCommunityAccess
   ELASTICSEARCH_ADDRESS: http://elasticsearch:9200


### PR DESCRIPTION
## Summary
- set production app logging to WARN to reduce INFO request and job log volume
- add sandbox New Relic Ruby agent sampling/log-forwarding controls
- preserve live sandbox SWAGGER_ENABLED value in the manifest
