### PR TITLE
Mount Argo token in sandbox app pods

### DIFF
--- a/terraform/environments/eks/k8s-manifests-sandbox/app-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/app-deployment.yaml
@@ -38,8 +38,14 @@ spec:
           env:
             - name: NEW_RELIC_APP_NAME
               value: "Credential Engine Sandbox"
+            - name: ARGO_WORKFLOWS_TOKEN_PATH
+              value: "/var/run/secrets/argo-workflows/token"
           ports:
             - containerPort: 9292
+          volumeMounts:
+            - name: argo-workflows-token
+              mountPath: /var/run/secrets/argo-workflows
+              readOnly: true
           envFrom:
             - secretRef:
                 name: app-secrets # DB credentials, APP_KEY, etc.
@@ -52,6 +58,13 @@ spec:
             limits:
               cpu: "1000m"
               memory: "1024Mi"
+      volumes:
+        - name: argo-workflows-token
+          secret:
+            secretName: argo-workflows-token
+            items:
+              - key: token
+                path: token
 
 ---
 apiVersion: v1

--- a/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
@@ -38,6 +38,8 @@ spec:
               value: "Credential Engine Sandbox"
             - name: PATH
               value: "/app/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            - name: ARGO_WORKFLOWS_TOKEN_PATH
+              value: "/var/run/secrets/argo-workflows/token"
           command: ["/bin/bash","-lc"]
           args:
             - |
@@ -51,6 +53,10 @@ spec:
                 name: app-secrets
             - configMapRef:
                 name: main-app-config
+          volumeMounts:
+            - name: argo-workflows-token
+              mountPath: /var/run/secrets/argo-workflows
+              readOnly: true
           resources:
             requests:
               cpu: "256m"
@@ -58,3 +64,10 @@ spec:
             limits:
               cpu: "1000m"
               memory: "2Gi"
+      volumes:
+        - name: argo-workflows-token
+          secret:
+            secretName: argo-workflows-token
+            items:
+              - key: token
+                path: token


### PR DESCRIPTION
## Summary
- mount the sandbox Argo token Secret into main-app and worker-app pods
- set ARGO_WORKFLOWS_TOKEN_PATH so the Ruby Argo client can read the bearer token from disk

## Notes
- this does not store token data in source control
- the target namespace must provide an argo-workflows-token Secret with a token key

## Testing
- parsed updated Kubernetes YAML manifests with Ruby YAML loader
- ran git diff --check
