### PR TITLE
Hotfix sandbox Elasticsearch resilience

### DIFF
--- a/terraform/environments/eks/k8s-manifests-sandbox/elasticsearch-statefulset.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/elasticsearch-statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app: elasticsearch
 spec:
   serviceName: elasticsearch-discovery
-  replicas: 2
+  replicas: 3
   podManagementPolicy: Parallel
   selector:
     matchLabels:

--- a/terraform/environments/eks/terraform.tfvars
+++ b/terraform/environments/eks/terraform.tfvars
@@ -15,7 +15,7 @@ image_tag_sandbox   = "sandbox"
 
 rds_engine_version = "17.5"
 allocated_storage  = 40
-cluster_version    = 1.33
+cluster_version    = 1.34
 
 db_username_sandbox = "ceregistrysandbox"
 db_username_staging = "ceregistrystaging"
@@ -34,8 +34,8 @@ ng_staging_max_size           = 6
 ng_sandbox_min_size           = 1
 ng_sandbox_desired_size       = 1
 ng_sandbox_max_size           = 5
-ng_sandbox_large_min_size     = 2
-ng_sandbox_large_desired_size = 2
+ng_sandbox_large_min_size     = 3
+ng_sandbox_large_desired_size = 3
 ng_sandbox_large_max_size     = 4
 ng_prod_min_size              = 2
 ng_prod_desired_size          = 2


### PR DESCRIPTION
Summary:
- Scale sandbox Elasticsearch to 3 replicas.
- Set sandbox large node group min/desired to 3 while keeping max at 4.
- Align Terraform EKS cluster_version with live 1.34.
