### PR TITLE
Enable production Swagger config

### DIFF
--- a/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
@@ -13,5 +13,6 @@ data:
   AIRBRAKE_PROJECT_ID: '270205'
   SIDEKIQ_CONCURRENCY: '10'
   LOG_LEVEL: "WARN"
+  SWAGGER_ENABLED: "true"
   API_KEY_VALIDATION_ENDPOINT: https://apps.credentialengine.org/accountsAPI/Organization/ValidateApiKey
   ELASTICSEARCH_ADDRESS: http://elasticsearch:9200


### PR DESCRIPTION
## Summary
- enable SWAGGER_ENABLED in the production app ConfigMap so /swagger.json is served
- keeps the production manifest aligned with the live hotfix applied for issue #1042

