### PR TITLE
Migrate credreg-prod to 16 GB nodes, raise main-app memory (#1056)

### DIFF
--- a/terraform/environments/eks/PROD-NODE-16G-MIGRATION.md
+++ b/terraform/environments/eks/PROD-NODE-16G-MIGRATION.md
@@ -1,0 +1,130 @@
+# Prod node resize to 16 GB — zero-downtime runbook (issue #1056)
+
+Blue/green migration of the `credreg-prod` workload from the `t3.large` (8 GB)
+`ng-prod` managed node group to a new `t3.xlarge` (16 GB) `ng-prod-v2` group.
+
+Root cause of the #1056 502s: `main-app` (4 GB limit) runs chronically at its
+memory ceiling and OOM-kills mid-publish. The 8 GB nodes cannot hold a larger
+`main-app` limit, so we move to 16 GB nodes first, then raise the limit.
+
+## Why blue/green (not an in-place edit)
+
+`ng-prod` is a managed node group with **no launch template**, so `instance_types`
+is ForceNew — editing it in place would destroy/recreate the whole prod node
+group. We add a parallel group, drain onto it, then remove the old one.
+
+## Facts established during preflight
+
+- `ng-prod` is dedicated to `credreg-prod` (main-app ×4, worker ×1, redis-0). ES is scaled to 0.
+- All pods: `nodeSelector env=production` + toleration for `env=production:NoSchedule`. `ng-prod-v2` replicates both.
+- No pod anti-affinity → pods repack freely.
+- PDBs: only `redis-pdb` (minAvailable=1) — blocks a normal drain of redis by design. main-app/worker have none.
+- `redis-0` is EBS gp3, PV **pinned to us-east-1b** → its replacement node must be in 1b.
+- EC2 quota: 1920 vCPU limit vs ~80 in use — ample for running both groups briefly.
+
+## Impact summary
+
+- **main-app**: zero user-facing impact (surge + drain behind a temp PDB).
+- **worker**: zero (scaled to 2 for the window).
+- **redis**: one deliberate ~15–30 s restart at the end. No data loss (EBS reattaches in 1b); not user-facing (cache + async Sidekiq broker). This is the only non-seamless step.
+
+---
+
+## Runbook
+
+Context: `--context credreg-eks -n credreg-prod`. Profile: `credreg-sso`.
+
+### 0. Baseline
+```
+kubectl --context credreg-eks -n credreg-prod get pods -o wide
+kubectl --context credreg-eks get nodes -l env=production -L node.kubernetes.io/instance-type,topology.kubernetes.io/zone
+```
+
+### 1. Create the new node group (targeted apply — avoids unrelated state drift)
+```
+cd terraform/environments/eks
+terraform plan            # expect: 1 to add (ng_prod_v2), 0 to destroy
+terraform apply -target=module.eks.aws_eks_node_group.ng_prod_v2
+```
+Wait for the new `t3.xlarge` nodes to be `Ready` and confirm they span **both** 1a and 1b:
+```
+kubectl --context credreg-eks get nodes -l env=production -L node.kubernetes.io/instance-type,topology.kubernetes.io/zone
+```
+Do not continue until at least one `t3.xlarge` is Ready in `us-east-1b` (for redis).
+
+### 2. Safety guards
+```
+kubectl --context credreg-eks -n credreg-prod apply -f - <<'EOF'
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: main-app-temp
+  namespace: credreg-prod
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: main-app
+EOF
+
+kubectl --context credreg-eks -n credreg-prod scale deploy worker-app --replicas=2
+kubectl --context credreg-eks -n credreg-prod rollout status deploy worker-app
+```
+
+### 3. Cordon the old t3.large prod nodes
+```
+for n in $(kubectl --context credreg-eks get nodes -l env=production \
+  -o jsonpath='{range .items[?(@.metadata.labels.node\.kubernetes\.io/instance-type=="t3.large")]}{.metadata.name}{"\n"}{end}'); do
+  kubectl --context credreg-eks cordon "$n"
+done
+```
+
+### 4. Drain the old nodes one at a time — EXCEPT redis's node (do it last)
+For each cordoned t3.large node that does **not** run `redis-0`:
+```
+kubectl --context credreg-eks drain <node> \
+  --ignore-daemonsets --delete-emptydir-data --skip-wait-for-delete-timeout=60 --timeout=300s
+# verify between each:
+kubectl --context credreg-eks -n credreg-prod get pods -o wide
+kubectl --context credreg-eks -n credreg-prod rollout status deploy main-app
+```
+main-app/worker pods reschedule onto the t3.xlarge nodes with no availability gap.
+
+### 5. Migrate redis last (the ~30 s blip)
+Confirm a `t3.xlarge` node is Ready in `us-east-1b`, then:
+```
+kubectl --context credreg-eks cordon <redis-old-node>        # if not already
+kubectl --context credreg-eks -n credreg-prod delete pod redis-0
+kubectl --context credreg-eks -n credreg-prod get pod redis-0 -o wide -w   # wait for 1/1 on a t3.xlarge in 1b
+```
+Verify the PV reattached and the app has no redis errors.
+
+### 6. Decommission the old node group
+Confirm the old nodes hold no non-daemonset pods, then remove the drained group:
+```
+terraform destroy -target=module.eks.aws_eks_node_group.ng_prod
+```
+Follow up (separate commit): delete the `ng_prod` resource + its variables from code.
+
+### 7. Restore
+```
+kubectl --context credreg-eks -n credreg-prod scale deploy worker-app --replicas=1
+# keep main-app-temp PDB (promote to a permanent manifest) — good hygiene
+```
+Optionally trim `ng_prod_v2_desired_size` toward steady state (~3) once stable.
+
+### 8. Raise main-app memory limit (separate PR)
+Now on 16 GB nodes, bump `main-app` `resources.limits.memory` (value TBD, e.g. 6–8Gi)
+in `k8s-manifests-prod/app-deployment.yaml` and apply. This is the change that
+actually fixes the OOM headroom; it is intentionally decoupled from the node move.
+
+## Rollback
+
+Before step 6, rollback is trivial (ng_prod is untouched):
+```
+for n in <old-nodes>; do kubectl --context credreg-eks uncordon "$n"; done
+terraform destroy -target=module.eks.aws_eks_node_group.ng_prod_v2
+kubectl --context credreg-eks -n credreg-prod scale deploy worker-app --replicas=1
+kubectl --context credreg-eks -n credreg-prod delete pdb main-app-temp
+```
+Pods reschedule back onto the original t3.large nodes.

--- a/terraform/environments/eks/k8s-manifests-prod/app-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-deployment.yaml
@@ -56,7 +56,7 @@ spec:
               memory: "3560Mi"
             limits:
               cpu: "1500m"
-              memory: "4Gi"
+              memory: "8Gi"
 
 ---
 apiVersion: v1

--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -127,9 +127,10 @@ module "eks" {
   ng_sandbox_large_min_size     = var.ng_sandbox_large_min_size
   ng_sandbox_large_desired_size = var.ng_sandbox_large_desired_size
   ng_sandbox_large_max_size     = var.ng_sandbox_large_max_size
-  ng_prod_min_size              = var.ng_prod_min_size
-  ng_prod_desired_size          = var.ng_prod_desired_size
-  ng_prod_max_size              = var.ng_prod_max_size
+  ng_prod_v2_instance_type      = var.ng_prod_v2_instance_type
+  ng_prod_v2_min_size           = var.ng_prod_v2_min_size
+  ng_prod_v2_desired_size       = var.ng_prod_v2_desired_size
+  ng_prod_v2_max_size           = var.ng_prod_v2_max_size
 }
 
 module "application_secret" {

--- a/terraform/environments/eks/terraform.tfvars
+++ b/terraform/environments/eks/terraform.tfvars
@@ -37,9 +37,13 @@ ng_sandbox_max_size           = 5
 ng_sandbox_large_min_size     = 2
 ng_sandbox_large_desired_size = 2
 ng_sandbox_large_max_size     = 4
-ng_prod_min_size              = 2
-ng_prod_desired_size          = 2
-ng_prod_max_size              = 8
+# Production node group: 16 GB t3.xlarge (issue #1056). Replaced the original
+# 8 GB t3.large group via blue/green migration. Sized to hold prod workload
+# (main-app, worker, redis) across 1a+1b with headroom.
+ng_prod_v2_instance_type = "t3.xlarge"
+ng_prod_v2_min_size      = 2
+ng_prod_v2_desired_size  = 4
+ng_prod_v2_max_size      = 8
 
 ecr_repository_name = "registry"
 # ---------------------------------------------------------------------------

--- a/terraform/environments/eks/variables.tf
+++ b/terraform/environments/eks/variables.tf
@@ -151,19 +151,25 @@ variable "ng_sandbox_large_max_size" {
   description = "Sandbox large (t3.large) node group max size"
 }
 
-variable "ng_prod_min_size" {
-  type        = number
-  description = "Production node group min size"
+variable "ng_prod_v2_instance_type" {
+  type        = string
+  description = "Replacement (16 GB) production node group instance type"
+  default     = "t3.xlarge"
 }
 
-variable "ng_prod_desired_size" {
+variable "ng_prod_v2_min_size" {
   type        = number
-  description = "Production node group desired size"
+  description = "Replacement production node group min size"
 }
 
-variable "ng_prod_max_size" {
+variable "ng_prod_v2_desired_size" {
   type        = number
-  description = "Production node group max size"
+  description = "Replacement production node group desired size"
+}
+
+variable "ng_prod_v2_max_size" {
+  type        = number
+  description = "Replacement production node group max size"
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/eks/node-groups-envs.tf
+++ b/terraform/modules/eks/node-groups-envs.tf
@@ -1,15 +1,19 @@
 # Dedicated environment node groups: prod, staging, sandbox
 
-resource "aws_eks_node_group" "ng_prod" {
+# Production node group (16 GB t3.xlarge). Replaced the original 8 GB t3.large
+# ng_prod group via a blue/green migration (issue #1056) so main-app has enough
+# memory headroom to publish large frameworks without OOM-killing. Kept named
+# _v2 to avoid a resource-address rename (which would force node replacement).
+resource "aws_eks_node_group" "ng_prod_v2" {
   cluster_name    = aws_eks_cluster.eks_cluster.name
-  node_group_name = "${var.cluster_name}-ng-prod"
+  node_group_name = "${var.cluster_name}-ng-prod-v2"
   node_role_arn   = aws_iam_role.eks_nodegroup_role.arn
   subnet_ids      = var.private_subnets
 
   ami_type       = "AL2023_x86_64_STANDARD"
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
-  instance_types = ["t3.large"]
+  instance_types = [var.ng_prod_v2_instance_type]
 
   labels = { env = "production" }
 
@@ -20,9 +24,9 @@ resource "aws_eks_node_group" "ng_prod" {
   }
 
   scaling_config {
-    desired_size = var.ng_prod_desired_size
-    min_size     = var.ng_prod_min_size
-    max_size     = var.ng_prod_max_size
+    desired_size = var.ng_prod_v2_desired_size
+    min_size     = var.ng_prod_v2_min_size
+    max_size     = var.ng_prod_v2_max_size
   }
 
   lifecycle { ignore_changes = [scaling_config[0].desired_size] }
@@ -38,7 +42,7 @@ resource "aws_eks_node_group" "ng_prod" {
   tags = merge(
     var.common_tags,
     {
-      Name                                            = "${var.cluster_name}-ng-prod"
+      Name                                            = "${var.cluster_name}-ng-prod-v2"
       "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned",
       "k8s.io/cluster-autoscaler/enabled"             = "true"
     }

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -120,19 +120,25 @@ variable "ng_sandbox_large_max_size" {
   description = "Sandbox large (t3.large) node group max size"
 }
 
-variable "ng_prod_min_size" {
-  type        = number
-  description = "Production node group min size"
+variable "ng_prod_v2_instance_type" {
+  type        = string
+  description = "Replacement (16 GB) production node group instance type"
+  default     = "t3.xlarge"
 }
 
-variable "ng_prod_desired_size" {
+variable "ng_prod_v2_min_size" {
   type        = number
-  description = "Production node group desired size"
+  description = "Replacement production node group min size"
 }
 
-variable "ng_prod_max_size" {
+variable "ng_prod_v2_desired_size" {
   type        = number
-  description = "Production node group max size"
+  description = "Replacement production node group desired size"
+}
+
+variable "ng_prod_v2_max_size" {
+  type        = number
+  description = "Replacement production node group max size"
 }
 
 variable "environment" {


### PR DESCRIPTION
## Summary
Fixes the recurring **502 Bad Gateway** on large competency-framework publishes (#1056). Root cause: `main-app` runs chronically at its **4Gi** memory ceiling and gets **OOM-killed mid-publish** — when the Puma worker dies, nginx returns 502. Over the last ~30 days main-app peaked at ~4Gi almost every day and OOM-killed on more than half of them. The 8 GB `t3.large` prod nodes can't host a larger memory limit (8Gi wouldn't even schedule on an 8 GB node), so prod is moved to 16 GB `t3.xlarge` nodes first, then the limit is raised.

## Changes
- **New prod node group `ng_prod_v2`** — `t3.xlarge` (16 GB), parameterized instance type/scaling, identical `env=production` label + `NoSchedule` taint and subnets as the old group.
- **Removed the retired `ng_prod`** resource and its `ng_prod_*` variables/tfvars.
- **`main-app` memory limit `4Gi → 8Gi`** in `k8s-manifests-prod/app-deployment.yaml` (request unchanged at 3560Mi).
- **Runbook** `PROD-NODE-16G-MIGRATION.md` documenting the blue/green migration + rollback.

## Rollout (already executed live, zero-downtime)
Blue/green: created `ng_prod_v2`, added a temp main-app PDB + scaled worker to 2, cordoned/drained the old nodes one-by-one (main-app held Ready throughout), migrated `redis-0` last (~28 s blip, EBS reattached in-AZ, no data loss), then destroyed `ng_prod`. Prod now runs solely on 2× t3.xlarge. No user-facing outage.

## Notes
- `ng_prod_v2` keeps the `_v2` name deliberately to avoid a resource-address rename (which would force node replacement).
- The `app-deployment.yaml` `image:`/`replicas:` fields remain CI-managed placeholders; only `limits.memory` changed here.
- A temporary `main-app` PodDisruptionBudget (`maxUnavailable=1`) was added live during migration and left in place as hygiene (the app previously had none). Consider promoting it to a permanent manifest.

Refs #1056