### PR TITLE
Sandbox: dedicated IRSA role + enable registry changeset sync

### DIFF
--- a/terraform/environments/eks/k8s-manifests-sandbox/app-configmap.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/app-configmap.yaml
@@ -25,3 +25,11 @@ data:
   NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED: "300"
   API_KEY_VALIDATION_ENDPOINT: https://sandbox.credentialengine.org/accountsAPI/Organization/ValidateCommunityAccess
   ELASTICSEARCH_ADDRESS: http://elasticsearch:9200
+  # Registry changeset sync -> Publisher (S3 auth via pod IRSA, not static keys)
+  # NOTE: endpoint host pending client confirmation
+  REGISTRY_CHANGESET_SYNC_ENDPOINT: https://api.publisher.sandbox.credentialengine.org/changeset/upload
+  REGISTRY_CHANGESET_SYNC_ENDPOINT_RETRY_INTERVAL_SECONDS: '30'
+  REGISTRY_CHANGESET_SYNC_DEBOUNCE_SECONDS: '60'
+  REGISTRY_CHANGESET_SYNC_ENDPOINT_TIMEOUT_SECONDS: '60'
+  REGISTRY_CHANGESET_SYNC_BUCKET: cer-registry-changesets-sandbox
+  AWS_REGION: us-east-1

--- a/terraform/environments/eks/k8s-manifests-sandbox/app-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       # DB migrations are handled via a dedicated Job
       containers:
         - name: main-app
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:sandbox
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           command: ["/bin/bash", "-c", "bin/rackup -o 0.0.0.0"]
           env:

--- a/terraform/environments/eks/k8s-manifests-sandbox/app-service-account.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/app-service-account.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   name: main-app-service-account
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::996810415034:role/ce-registry-eks-application-irsa-role"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::996810415034:role/ce-registry-eks-sandbox-application-irsa-role"

--- a/terraform/environments/eks/k8s-manifests-sandbox/db-migrate-job.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/db-migrate-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: db-migrate
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:sandbox
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           command: ["/bin/bash","-lc","bundle exec rake db:migrate RACK_ENV=production"]
           envFrom:

--- a/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: main-app-service-account
       containers:
         - name: worker
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:sandbox
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           env:
             - name: NEW_RELIC_APP_NAME

--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -212,6 +212,20 @@ output "cer_envelope_graphs_bucket_name_sandbox" {
   description = "Sandbox S3 bucket name for envelope graphs"
 }
 
+## Sandbox S3: Registry Changesets (changeset sync stores the ZIP here before
+## POSTing it to the Publisher endpoint). Reuses the generic bucket module.
+module "changeset_sync_s3_sandbox" {
+  source      = "../../modules/envelope_graphs_s3"
+  bucket_name = "cer-registry-changesets-sandbox"
+  environment = "sandbox"
+  common_tags = local.common_tags
+}
+
+output "cer_registry_changesets_bucket_name_sandbox" {
+  value       = module.changeset_sync_s3_sandbox.bucket_name
+  description = "Sandbox S3 bucket for registry changeset sync"
+}
+
 ## Production S3: Envelope Graphs (module)
 module "envelope_graphs_s3_prod" {
   source      = "../../modules/envelope_graphs_s3"

--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -298,6 +298,45 @@ resource "aws_iam_role_policy" "github_oidc_db_dumps" {
   })
 }
 
+# Allow the GitHub OIDC (Terraform CI) role to refresh registry changeset sync
+# buckets during `terraform plan` — the AWS provider reads bucket config (CORS,
+# versioning, encryption, ownership controls, public-access-block, tags, etc.)
+# on every managed bucket. Scoped to the cer-registry-changesets-* buckets.
+resource "aws_iam_role_policy" "github_oidc_changeset_buckets" {
+  name = "changeset-buckets-read"
+  role = data.aws_iam_role.github_oidc.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ChangesetBucketsRead"
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketCORS",
+          "s3:GetBucketWebsite",
+          "s3:GetBucketVersioning",
+          "s3:GetBucketAcl",
+          "s3:GetBucketLogging",
+          "s3:GetBucketLocation",
+          "s3:GetBucketTagging",
+          "s3:GetBucketRequestPayment",
+          "s3:GetBucketObjectLockConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetBucketPolicyStatus",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:GetBucketOwnershipControls",
+          "s3:ListBucket",
+        ]
+        Resource = "arn:aws:s3:::cer-registry-changesets-*"
+      }
+    ]
+  })
+}
+
 ## CloudWatch Log Forwarding to Slack
 module "cloudwatch_slack_forwarder" {
   source            = "../../modules/cloudwatch_slack_forwarder"

--- a/terraform/modules/eks/irsa-iam-policy-and-role.tf
+++ b/terraform/modules/eks/irsa-iam-policy-and-role.tf
@@ -172,3 +172,82 @@ output "application_irsa_role_arn" {
   description = "IRSA application IAM Role ARN"
   value       = aws_iam_role.application_irsa_role.arn
 }
+
+
+## Dedicated IRSA role for the sandbox application.
+## Isolated from the shared staging/prod application role above so the sandbox
+## workload cannot read/write production S3 (envelope-graphs-prod, db-dumps-prod,
+## etc.). Scoped to only the buckets the sandbox Registry app actually uses.
+resource "aws_iam_role" "application_irsa_role_sandbox" {
+  name = "${var.cluster_name}-sandbox-application-irsa-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.oidc_provider.arn
+        }
+        Condition = {
+          StringEquals = {
+            "${replace(aws_iam_openid_connect_provider.oidc_provider.url, "https://", "")}:sub" = "system:serviceaccount:${var.app_namespace_sandbox}:${var.app_service_account_sandbox}",
+            "${replace(aws_iam_openid_connect_provider.oidc_provider.url, "https://", "")}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Terraform   = "true"
+    Environment = "${var.cluster_name}-sandbox"
+  }
+}
+
+resource "aws_iam_policy" "application_policy_sandbox" {
+  name        = "${var.cluster_name}-sandbox-application-policy"
+  description = "Least-privilege S3 permissions for the sandbox Registry application"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "S3ObjectRW",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ],
+        "Resource" : [
+          "arn:aws:s3:::cer-envelope-downloads/*",
+          "arn:aws:s3:::cer-envelope-graphs-sandb/*"
+        ]
+      },
+      {
+        "Sid" : "S3BucketReadMeta",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        "Resource" : [
+          "arn:aws:s3:::cer-envelope-downloads",
+          "arn:aws:s3:::cer-envelope-graphs-sandb"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "application_irsa_role_sandbox_attach" {
+  role       = aws_iam_role.application_irsa_role_sandbox.name
+  policy_arn = aws_iam_policy.application_policy_sandbox.arn
+}
+
+output "application_irsa_role_sandbox_arn" {
+  description = "IRSA sandbox application IAM Role ARN"
+  value       = aws_iam_role.application_irsa_role_sandbox.arn
+}

--- a/terraform/modules/eks/irsa-iam-policy-and-role.tf
+++ b/terraform/modules/eks/irsa-iam-policy-and-role.tf
@@ -67,9 +67,11 @@ output "cert_manager_irsa_role_arn" {
 ## IRSA for app
 
 locals {
+  # Sandbox intentionally excluded — the sandbox app uses its own dedicated
+  # least-privilege role (application_irsa_role_sandbox) so it cannot assume
+  # this shared role or reach production S3.
   app_irsa_subjects = [
     "system:serviceaccount:${var.app_namespace}:${var.app_service_account}",
-    "system:serviceaccount:${var.app_namespace_sandbox}:${var.app_service_account_sandbox}",
     "system:serviceaccount:${var.app_namespace_prod}:${var.app_service_account_prod}"
   ]
 }

--- a/terraform/modules/eks/irsa-iam-policy-and-role.tf
+++ b/terraform/modules/eks/irsa-iam-policy-and-role.tf
@@ -225,7 +225,8 @@ resource "aws_iam_policy" "application_policy_sandbox" {
         ],
         "Resource" : [
           "arn:aws:s3:::cer-envelope-downloads/*",
-          "arn:aws:s3:::cer-envelope-graphs-sandb/*"
+          "arn:aws:s3:::cer-envelope-graphs-sandb/*",
+          "arn:aws:s3:::cer-registry-changesets-sandbox/*"
         ]
       },
       {
@@ -237,7 +238,8 @@ resource "aws_iam_policy" "application_policy_sandbox" {
         ],
         "Resource" : [
           "arn:aws:s3:::cer-envelope-downloads",
-          "arn:aws:s3:::cer-envelope-graphs-sandb"
+          "arn:aws:s3:::cer-envelope-graphs-sandb",
+          "arn:aws:s3:::cer-registry-changesets-sandbox"
         ]
       }
     ]


### PR DESCRIPTION
Promotes the registry changeset sync feature to **sandbox** (`credreg-sandbox` on `ce-registry-eks`), and first isolates sandbox onto a dedicated least-privilege IRSA role.

## 1. Dedicated sandbox IRSA role (isolation)
Previously the sandbox app shared `ce-registry-eks-application-irsa-role` with **staging + prod**, which granted it RW to production S3 (`cer-envelope-graphs-prod`, `cer-db-dumps-prod`).
- New `ce-registry-eks-sandbox-application-irsa-role` trusting only `credreg-sandbox:main-app-service-account`, scoped to the buckets the sandbox app actually uses (verified against the app's S3 code paths + the sandbox DB — OCN export disabled for all sandbox communities).
- Removed `credreg-sandbox` from the shared role's trust.
- Repointed `k8s-manifests-sandbox/app-service-account.yaml`.

## 2. Changeset sync
- New `cer-registry-changesets-sandbox` bucket, granted on the dedicated sandbox policy.
- `app-configmap.yaml`: `REGISTRY_CHANGESET_SYNC_*` + `AWS_REGION` (endpoint = sandbox publisher). S3 auth via pod IRSA, no static credentials.
- Bumped app/worker/db-migrate images from floating `registry:sandbox` (`2026.05.18.0152`, predates the feature) to immutable `2026.07.30.0154` (commit `32ffd06`, the build validated in test).

## Deployed & verified (live)
- Terraform applied (role, bucket, grants). SA repointed; sandbox pod denied on prod buckets, cannot assume the shared role.
- DB migrated (`RemoveArgoFields`, `AddPayloadToEnvelopeResourceSyncEvents`).
- App/worker on `2026.07.30.0154`, 1/1 ready. IRSA write to changeset bucket OK. Publisher endpoint reachable (405) with egress `107.21.182.55` allowlisted (confirmed by publisher team).

## Follow-up
- End-to-end round-trip (publish → changeset → Publisher `201`) pending a sandbox publish.