### PR TITLE
Prod changeset sync — Stage 1: infra prep (bucket + dedicated IRSA role)

### DIFF
--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -240,6 +240,20 @@ output "cer_envelope_graphs_bucket_name_prod" {
   description = "Production S3 bucket name for envelope graphs"
 }
 
+## Production S3: Registry Changesets (changeset sync stores the ZIP here before
+## POSTing it to the Publisher endpoint). Reuses the generic bucket module.
+module "changeset_sync_s3_prod" {
+  source      = "../../modules/envelope_graphs_s3"
+  bucket_name = "cer-registry-changesets-prod"
+  environment = "production"
+  common_tags = local.common_tags
+}
+
+output "cer_registry_changesets_bucket_name_prod" {
+  value       = module.changeset_sync_s3_prod.bucket_name
+  description = "Production S3 bucket for registry changeset sync"
+}
+
 ## DB Dumps S3 bucket
 module "db_dumps_s3" {
   source          = "../../modules/db_dumps_s3"

--- a/terraform/modules/eks/irsa-iam-policy-and-role.tf
+++ b/terraform/modules/eks/irsa-iam-policy-and-role.tf
@@ -255,3 +255,87 @@ output "application_irsa_role_sandbox_arn" {
   description = "IRSA sandbox application IAM Role ARN"
   value       = aws_iam_role.application_irsa_role_sandbox.arn
 }
+
+
+## Dedicated IRSA role for the production application.
+## Isolated from the shared staging/prod application role above so prod runs on
+## a least-privilege role scoped to only the buckets the prod Registry app
+## actually uses (verified: downloads, prod envelope-graphs, ocn-exports for the
+## ce_registry OCN export, and the prod changeset bucket).
+resource "aws_iam_role" "application_irsa_role_prod" {
+  name = "${var.cluster_name}-prod-application-irsa-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.oidc_provider.arn
+        }
+        Condition = {
+          StringEquals = {
+            "${replace(aws_iam_openid_connect_provider.oidc_provider.url, "https://", "")}:sub" = "system:serviceaccount:${var.app_namespace_prod}:${var.app_service_account_prod}",
+            "${replace(aws_iam_openid_connect_provider.oidc_provider.url, "https://", "")}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Terraform   = "true"
+    Environment = "${var.cluster_name}-prod"
+  }
+}
+
+resource "aws_iam_policy" "application_policy_prod" {
+  name        = "${var.cluster_name}-prod-application-policy"
+  description = "Least-privilege S3 permissions for the production Registry application"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "S3ObjectRW",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ],
+        "Resource" : [
+          "arn:aws:s3:::cer-envelope-downloads/*",
+          "arn:aws:s3:::cer-envelope-graphs-prod-us-east-1/*",
+          "arn:aws:s3:::ocn-exports/*",
+          "arn:aws:s3:::cer-registry-changesets-prod/*"
+        ]
+      },
+      {
+        "Sid" : "S3BucketReadMeta",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        "Resource" : [
+          "arn:aws:s3:::cer-envelope-downloads",
+          "arn:aws:s3:::cer-envelope-graphs-prod-us-east-1",
+          "arn:aws:s3:::ocn-exports",
+          "arn:aws:s3:::cer-registry-changesets-prod"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "application_irsa_role_prod_attach" {
+  role       = aws_iam_role.application_irsa_role_prod.name
+  policy_arn = aws_iam_policy.application_policy_prod.arn
+}
+
+output "application_irsa_role_prod_arn" {
+  description = "IRSA production application IAM Role ARN"
+  value       = aws_iam_role.application_irsa_role_prod.arn
+}


### PR DESCRIPTION
**Stage 1 (infrastructure prep) for enabling registry changeset sync in production.** Additive only; does **not** touch the running prod app.

## Status: APPLIED (2026-08-11)
Applied to prod via a **targeted apply** of only these resources — verified **8 added, 0 changed, 0 destroyed**. Live-verified: bucket is private (public-access-block) + versioned + AES256; role trusts only `credreg-prod:main-app-service-account`. The pre-existing Phase-2 drift below was **deliberately left untouched**. This PR merges to bring `master` in sync with what's applied.

## What this adds
- **S3 bucket** `cer-registry-changesets-prod` (versioning + AES256 + public-access-block).
- **Dedicated prod IRSA role** `ce-registry-eks-prod-application-irsa-role`, trusting only `credreg-prod:main-app-service-account` — isolates prod from the shared staging/prod role.
- **Scoped policy** = the buckets prod actually uses (verified against S3 code paths + DB config):
  `cer-envelope-downloads`, `cer-envelope-graphs-prod-us-east-1`, **`ocn-exports`** (prod `ce_registry` OCN export is enabled), `cer-registry-changesets-prod`.

## Deferred to Stage 2 (app cutover) — intentionally not here
- Repoint prod SA → new role (needs a pod roll; done in lockstep with the new image).
- Configmap `REGISTRY_CHANGESET_SYNC_*` vars (endpoint initially unset), image bump to `2026.07.30.0154`, DB migration, and **sync-marker reset** to avoid the historical backlog.

## Note on the CI plan
A full plan here also shows the pre-existing Phase-2 drift (db-dumps policy, `ng_sandbox_large` min_size, rds-sandbox SG) — those are **not** from this PR and were not applied. They will be reconciled separately.
