### PR TITLE
Prod changeset sync — Stage 2: app cutover (configmap, SA, image pin, runbook)

### DIFF
--- a/terraform/environments/eks/PROD-CHANGESET-CUTOVER-RUNBOOK.md
+++ b/terraform/environments/eks/PROD-CHANGESET-CUTOVER-RUNBOOK.md
@@ -1,0 +1,77 @@
+# Prod Changeset Sync — Stage 2 Cutover Runbook
+
+Deploys the registry changeset-sync feature (image `2026.07.30.0154`) to `credreg-prod`.
+**Stage 1 (infra: `cer-registry-changesets-prod` bucket + dedicated prod IRSA role) is already applied.**
+
+Deploy with `REGISTRY_CHANGESET_SYNC_ENDPOINT` **unset**: changesets are generated + stored in S3
+but not delivered, so the Publisher blob can be backfilled first, then the endpoint is set.
+
+## Preconditions
+- [ ] Stage-1 infra live: bucket `cer-registry-changesets-prod` + role `ce-registry-eks-prod-application-irsa-role` (verified).
+- [ ] PR #1061 (Stage 1) merged so `master` matches applied infra.
+- [ ] This branch (`feat/prod-changeset-cutover`) reviewed: configmap vars (endpoint omitted), SA repoint, image pins.
+- [ ] Cary aware of the target time and the endpoint-set-after-backfill sequence.
+
+## Cutover sequence
+
+### 1. Reset the `ce_registry` marker (image-independent — run first)
+Safe to run **before** the image deploy: the current prod image is pre-feature and never runs the
+sync job, so nothing acts on the marker until the new image is up. This pre-empts the ~89K-version
+backlog (which would otherwise be one ~180 MB ZIP under the publish-lock). Only `ce_registry` has a
+stale row; other communities self-initialize on first publish.
+
+Run over the bastion tunnel as the app user (`credential_registry_production` has UPDATE):
+```sql
+UPDATE registry_changeset_syncs rcs
+SET last_synced_version_id          = mx.max_v,
+    last_activity_version_id        = GREATEST(COALESCE(rcs.last_activity_version_id,0), mx.max_v),
+    last_synced_resource_event_id   = COALESCE(mx.max_e, rcs.last_synced_resource_event_id),
+    last_activity_resource_event_id = GREATEST(COALESCE(rcs.last_activity_resource_event_id,0), COALESCE(mx.max_e,0)),
+    last_activity_at = now(), updated_at = now()
+FROM envelope_communities ec
+JOIN LATERAL (
+  SELECT (SELECT max(v.id) FROM versions v
+            WHERE v.item_type='Envelope' AND v.envelope_community_id = ec.id) AS max_v,
+         (SELECT max(e.id) FROM envelope_resource_sync_events e
+            WHERE e.envelope_community_id = ec.id) AS max_e
+) mx ON true
+WHERE ec.id = rcs.envelope_community_id AND ec.name = 'ce_registry';
+```
+Verify: `last_synced_version_id` now equals `max(versions.id)` for `ce_registry`.
+
+### 2. Apply SA repoint + configmap (no restart yet)
+```bash
+kubectl --context ce-registry-eks apply -f k8s-manifests-prod/app-service-account.yaml
+kubectl --context ce-registry-eks apply -f k8s-manifests-prod/app-configmap.yaml
+```
+
+### 3. Deploy the image (runs the migration)
+Dispatch the **"Deploy image"** workflow: `image_label=2026.07.30.0154`, `environment=production`.
+It `set image`s main-app + worker-app, rolls + restarts (pods pick up new SA role + configmap),
+then runs the `db-migrate` job (`RemoveArgoFields`). Migration runs **after** rollout, so the new
+pods (which don't use the Argo columns) are up before the columns are dropped.
+
+### 4. Verify
+- [ ] Pods `2026.07.30.0154`, Running; no `CreateContainerConfigError`/OOM.
+- [ ] `AWS_REGION` + `REGISTRY_CHANGESET_SYNC_*` present in pods; endpoint **absent**.
+- [ ] IRSA: pod can write to `s3://cer-registry-changesets-prod` (assumed role = `…-prod-application-irsa-role`).
+- [ ] Trigger one small publish → a changeset ZIP lands in S3, marker advances, `last_sync_error` nil, publish-lock < a few seconds.
+- [ ] Watch worker memory / in-process indexing lag under real load.
+
+### 5. (After Cary's backfill) set the endpoint
+Once Cary has seeded the blob and applied the accumulated S3 changesets, add to the configmap and
+restart:
+```
+REGISTRY_CHANGESET_SYNC_ENDPOINT: https://api.publisher.credentialengine.org/changeset/upload
+```
+via the **"Apply configmap and restart"** workflow (`environment=production`).
+**Gap note:** changesets generated between Cary's last "apply" pass and the endpoint going live are
+in S3 but not delivered (delivery is not retroactive). Coordinate so Cary does a final apply pass
+right at endpoint-set, ideally in the low-traffic window (Sun ~05:00 UTC), to minimize the gap.
+
+## Rollback
+- Pre-migration: redeploy the previous image (`2026.04.24.0146`) via the Deploy workflow; revert SA
+  annotation to `ce-registry-eks-application-irsa-role`; remove changeset vars from the configmap.
+- Post-migration: `RemoveArgoFields` is destructive (drops Argo columns). Rolling back to the
+  Argo-based image after the migration requires restoring those columns — treat the migration as the
+  point of no easy return; take an RDS snapshot immediately before Step 3.

--- a/terraform/environments/eks/PROD-CHANGESET-CUTOVER-RUNBOOK.md
+++ b/terraform/environments/eks/PROD-CHANGESET-CUTOVER-RUNBOOK.md
@@ -44,6 +44,11 @@ Verify: `last_synced_version_id` now equals `max(versions.id)` for `ce_registry`
 kubectl --context ce-registry-eks apply -f k8s-manifests-prod/app-service-account.yaml
 kubectl --context ce-registry-eks apply -f k8s-manifests-prod/app-configmap.yaml
 ```
+**Intentional configmap delta:** besides adding the 5 changeset/`AWS_REGION` keys, this apply
+also **drops `ARGO_WORKFLOWS_MAX_WORKERS`** — a live-only key added out-of-band that was never in the
+tracked manifest. This is deliberate: the new image is Argo-less and doesn't read it. It's timing-safe
+because we apply without a restart, so running (old) pods keep their env until the image swap in Step 3.
+This is the only live key removed; no existing values change.
 
 ### 3. Deploy the image (runs the migration)
 Dispatch the **"Deploy image"** workflow: `image_label=2026.07.30.0154`, `environment=production`.

--- a/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-configmap.yaml
@@ -16,3 +16,13 @@ data:
   SWAGGER_ENABLED: "true"
   API_KEY_VALIDATION_ENDPOINT: https://apps.credentialengine.org/accountsAPI/Organization/ValidateApiKey
   ELASTICSEARCH_ADDRESS: http://elasticsearch:9200
+  # Registry changeset sync -> Publisher (S3 auth via pod IRSA, not static keys).
+  # REGISTRY_CHANGESET_SYNC_ENDPOINT is intentionally UNSET for the initial cutover:
+  # changesets are generated + stored in S3 but not delivered, so the Publisher blob
+  # can be backfilled first. The endpoint is added only after the backfill completes
+  # (-> https://api.publisher.credentialengine.org/changeset/upload).
+  REGISTRY_CHANGESET_SYNC_BUCKET: cer-registry-changesets-prod
+  REGISTRY_CHANGESET_SYNC_DEBOUNCE_SECONDS: '60'
+  REGISTRY_CHANGESET_SYNC_ENDPOINT_RETRY_INTERVAL_SECONDS: '30'
+  REGISTRY_CHANGESET_SYNC_ENDPOINT_TIMEOUT_SECONDS: '60'
+  AWS_REGION: us-east-1

--- a/terraform/environments/eks/k8s-manifests-prod/app-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: main-app-service-account
       containers:
         - name: main-app
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:master
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           command: ["/bin/bash", "-c", "bin/rackup -o 0.0.0.0"]
           env:

--- a/terraform/environments/eks/k8s-manifests-prod/app-service-account.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-service-account.yaml
@@ -4,5 +4,5 @@ metadata:
   name: main-app-service-account
   namespace: credreg-prod
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::996810415034:role/ce-registry-eks-application-irsa-role"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::996810415034:role/ce-registry-eks-prod-application-irsa-role"
 

--- a/terraform/environments/eks/k8s-manifests-prod/db-migrate-job.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/db-migrate-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: db-migrate
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:production
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           command: ["/bin/bash","-lc","bundle exec rake db:migrate RACK_ENV=production"]
           envFrom:

--- a/terraform/environments/eks/k8s-manifests-prod/worker-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: main-app-service-account
       containers:
         - name: worker
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:master
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/registry:2026.07.30.0154
           imagePullPolicy: Always
           env:
             - name: NEW_RELIC_APP_NAME


### PR DESCRIPTION
**Stage 2 (app cutover) for registry changeset sync in production.** Depends on Stage 1 (#1061, infra — already applied). **Draft — do not merge/apply until the deploy window.**

## Changes (`k8s-manifests-prod/`)
- **app-configmap**: add `REGISTRY_CHANGESET_SYNC_*` + `AWS_REGION`. **`REGISTRY_CHANGESET_SYNC_ENDPOINT` intentionally omitted** — changesets generate + store in S3 but aren't delivered, so the Publisher blob can be backfilled first; endpoint is set afterward.
- **app-service-account**: repoint to the dedicated least-privilege `ce-registry-eks-prod-application-irsa-role` (verified: db-dump jobs use a separate SA, so nothing loses bucket access).
- **app/worker/db-migrate**: pin immutable image `2026.07.30.0154` (was floating `:master`/`:production`). Tag verified in ECR.
- **RUNBOOK**: full ordered cutover (marker reset → apply SA+configmap → Deploy workflow + migration → verify → set endpoint after backfill) + rollback notes.

## Key deploy facts
- Marker reset needed for **`ce_registry` only** (stale row ~89K versions behind); other communities self-initialize on first publish. Reset runs first (image-independent) to pre-empt the ~180 MB backlog ZIP under the publish-lock.
- The **Deploy image** workflow runs the migration **after** the rollout, so new pods (which don't use the Argo columns) are up before `RemoveArgoFields` drops them.
- Configmap + SA are **not** applied by the Deploy workflow — applied separately per the runbook.

## Not in this PR
- Setting `REGISTRY_CHANGESET_SYNC_ENDPOINT` (post-backfill, via configmap workflow).
- Publisher-side blob backfill (Cary) + accumulated-changeset apply.
