### PR TITLE
Make changeset endpoint delivery attempts configurable (disable retries via env)

### DIFF
--- a/app/services/sync_pending_registry_changesets.rb
+++ b/app/services/sync_pending_registry_changesets.rb
@@ -188,7 +188,7 @@ class SyncPendingRegistryChangesets
 
       MR.logger.error(
         "Registry changeset endpoint delivery failed for #{key} after " \
-        "#{max_attempts} attempt(s): #{e.class}: #{e.message}"
+        "#{max_attempts} attempts: #{e.class}: #{e.message}"
       )
       Airbrake.notify(e) if defined?(Airbrake)
     end

--- a/app/services/sync_pending_registry_changesets.rb
+++ b/app/services/sync_pending_registry_changesets.rb
@@ -171,15 +171,16 @@ class SyncPendingRegistryChangesets
 
   def deliver_changeset_to_endpoint(body, key)
     attempt = 0
+    max_attempts = changeset_endpoint_attempts
 
     begin
       attempt += 1
       post_changeset_zip(body, key)
     rescue StandardError => e
-      if attempt < ENDPOINT_DELIVERY_ATTEMPTS
+      if attempt < max_attempts
         MR.logger.warn(
           "Registry changeset endpoint delivery attempt #{attempt} of " \
-          "#{ENDPOINT_DELIVERY_ATTEMPTS} failed for #{key}: #{e.class}: #{e.message}"
+          "#{max_attempts} failed for #{key}: #{e.class}: #{e.message}"
         )
         sleep(changeset_endpoint_retry_interval)
         retry
@@ -187,7 +188,7 @@ class SyncPendingRegistryChangesets
 
       MR.logger.error(
         "Registry changeset endpoint delivery failed for #{key} after " \
-        "#{ENDPOINT_DELIVERY_ATTEMPTS} attempts: #{e.class}: #{e.message}"
+        "#{max_attempts} attempt(s): #{e.class}: #{e.message}"
       )
       Airbrake.notify(e) if defined?(Airbrake)
     end
@@ -225,6 +226,15 @@ class SyncPendingRegistryChangesets
 
   def changeset_endpoint_retry_interval
     [(ENV['REGISTRY_CHANGESET_SYNC_ENDPOINT_RETRY_INTERVAL_SECONDS'].presence || '30').to_i, 0].max
+  end
+
+  # Total number of delivery attempts (not retries). Set to 1 to disable retries
+  # entirely — the endpoint is POSTed exactly once. Defaults to ENDPOINT_DELIVERY_ATTEMPTS.
+  def changeset_endpoint_attempts
+    [
+      (ENV['REGISTRY_CHANGESET_SYNC_ENDPOINT_ATTEMPTS'].presence || ENDPOINT_DELIVERY_ATTEMPTS).to_i,
+      1
+    ].max
   end
 
   def changeset_zip(actions)


### PR DESCRIPTION
## What
Makes the number of changeset → Publisher **delivery attempts** configurable via a new env var `REGISTRY_CHANGESET_SYNC_ENDPOINT_ATTEMPTS` (default `3`, minimum `1`). Previously the attempt count was hardcoded (`ENDPOINT_DELIVERY_ATTEMPTS = 3`) with no way to tune it.

Setting it to **`1`** makes the registry POST each changeset to the Publisher **exactly once — no retries.**

## Why
The Publisher **stores** the changeset on the first POST (it currently returns a non-2xx only on a later workflow-submission step). On our side, any non-2xx is treated as a failed delivery and retried up to 3× **under the publish-lock**, which (a) re-POSTs/re-stores the same changeset multiple times on the Publisher side and (b) holds the publish-lock longer. The Publisher team asked us **not to retry** the upload endpoint. The only retry-related config today is the *interval*, not the *count* — so this needs a code change.

## Change
- `changeset_endpoint_attempts` reads `REGISTRY_CHANGESET_SYNC_ENDPOINT_ATTEMPTS` (defaults to the existing constant, clamped to ≥ 1).
- `deliver_changeset_to_endpoint` uses it instead of the hardcoded constant. No behavior change unless the env var is set.

## To activate in prod (separate config, not in this PR)
Set in the `credreg-prod` configmap and deploy the new image:
```
REGISTRY_CHANGESET_SYNC_ENDPOINT_ATTEMPTS: "1"
```
Default (3) is unchanged for all other environments.
