### PR TITLE
Cap prod app node pool at 3 and stop memory-based autoscaling

### DIFF
--- a/terraform/environments/eks/k8s-manifests-prod/app-hpa.yaml
+++ b/terraform/environments/eks/k8s-manifests-prod/app-hpa.yaml
@@ -8,8 +8,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: main-app
-  minReplicas: 1
-  maxReplicas: 10
+  minReplicas: 2
+  maxReplicas: 4
   metrics:
     - type: Resource
       resource:
@@ -17,9 +17,8 @@ spec:
         target:
           type: Utilization
           averageUtilization: 90
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 95
+    # Memory-based scaling removed on purpose: main-app memory climbs with pod
+    # uptime rather than with load, so scaling on memory made the HPA add
+    # replicas chasing that growth. Each new replica pulled in more nodes, which
+    # reserved subnet IPs and drove the EKS cluster's IP-exhaustion health alert.
+    # Scale on CPU (real load) until the underlying memory growth is addressed.

--- a/terraform/environments/eks/terraform.tfvars
+++ b/terraform/environments/eks/terraform.tfvars
@@ -42,8 +42,8 @@ ng_sandbox_large_max_size     = 4
 # (main-app, worker, redis) across 1a+1b with headroom.
 ng_prod_v2_instance_type = "t3.xlarge"
 ng_prod_v2_min_size      = 2
-ng_prod_v2_desired_size  = 4
-ng_prod_v2_max_size      = 8
+ng_prod_v2_desired_size  = 2
+ng_prod_v2_max_size      = 3
 
 ecr_repository_name = "registry"
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context
Prod EKS cluster `ce-registry-eks` raised an IP-exhaustion health alert (CredentialEngine/CredentialRegistry#1063). Root cause was a feedback loop, not a networking capacity problem.

## Root cause
The `main-app` HPA scaled on **memory utilization**. Since `main-app` memory grows with pod uptime rather than with load, the HPA kept adding replicas chasing that growth → cluster-autoscaler added nodes → each node reserved a VPC-CNI warm pool of IPs → the `/24` private subnet in `us-east-1b` dropped to ~8 free addresses → EKS health alert.

## Changes
| File | Change | Why |
|---|---|---|
| `app-hpa.yaml` | remove the memory metric (CPU-only); `minReplicas 2`, `maxReplicas 4` | Autoscaling tracks real load instead of the leak; pod count can't overrun the node pool |
| `terraform.tfvars` | `ng_prod_v2` cap `min 2 / max 3`.

Memory request/limit are **left unchanged** (3560Mi / 8Gi) so the app's memory growth stays visible and reproducible rather than being masked. That app-side work is tracked separately by the application team.

## Scope
Stabilization to keep the cluster patchable ahead of the **2026-08-19** EKS platform patch. Relates to CredentialEngine/CredentialRegistry#1063.