### PR TITLE
sandbox: consolidate to 2x t3.medium

### DIFF
--- a/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/worker-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           resources:
             requests:
               cpu: "256m"
-              memory: "2Gi"            
+              memory: "768Mi" # right-sized: observed ~531Mi; limit kept at 2Gi for burst
             limits:
               cpu: "1000m"
               memory: "2Gi"

--- a/terraform/environments/eks/terraform.tfvars
+++ b/terraform/environments/eks/terraform.tfvars
@@ -28,13 +28,13 @@ priv_ng_instance_type  = "t3.large"
 route53_hosted_zone_id = "Z1N75467P1FUL5"
 
 # Env node group scaling
-ng_staging_min_size           = 1
-ng_staging_desired_size       = 1
-ng_staging_max_size           = 6
+ng_staging_min_size     = 1
+ng_staging_desired_size = 1
+ng_staging_max_size     = 6
 # Sandbox consolidated to 2x t3.medium (client request: 2 medium/small VMs).
-ng_sandbox_min_size           = 2
-ng_sandbox_desired_size       = 2
-ng_sandbox_max_size           = 5
+ng_sandbox_min_size     = 2
+ng_sandbox_desired_size = 2
+ng_sandbox_max_size     = 5
 # t3.large sandbox group retired — workloads consolidated onto ng_sandbox (t3.medium).
 # min=0 lets cluster-autoscaler drain it; max kept >=1 (EKS constraint).
 ng_sandbox_large_min_size     = 0

--- a/terraform/environments/eks/terraform.tfvars
+++ b/terraform/environments/eks/terraform.tfvars
@@ -31,11 +31,14 @@ route53_hosted_zone_id = "Z1N75467P1FUL5"
 ng_staging_min_size           = 1
 ng_staging_desired_size       = 1
 ng_staging_max_size           = 6
-ng_sandbox_min_size           = 1
-ng_sandbox_desired_size       = 1
+# Sandbox consolidated to 2x t3.medium (client request: 2 medium/small VMs).
+ng_sandbox_min_size           = 2
+ng_sandbox_desired_size       = 2
 ng_sandbox_max_size           = 5
-ng_sandbox_large_min_size     = 2
-ng_sandbox_large_desired_size = 2
+# t3.large sandbox group retired — workloads consolidated onto ng_sandbox (t3.medium).
+# min=0 lets cluster-autoscaler drain it; max kept >=1 (EKS constraint).
+ng_sandbox_large_min_size     = 0
+ng_sandbox_large_desired_size = 0
 ng_sandbox_large_max_size     = 4
 # Production node group: 16 GB t3.xlarge (issue #1056). Replaced the original
 # 8 GB t3.large group via blue/green migration. Sized to hold prod workload


### PR DESCRIPTION
## Summary

Consolidates the **sandbox** environment on `ce-registry-eks` from **3 nodes (1× t3.medium + 2× t3.large)** down to **2× t3.medium**, per the client request to reduce sandbox to 2 medium/small VMs.

## Why it fits
The sandbox node groups are dedicated (`env` taint) and run only the app pods + DaemonSets — platform services live on other node groups. Live footprint is small:

| Pod | Mem request | Observed usage |
|---|---|---|
| main-app ×2 | 512Mi ea | ~460–570Mi |
| worker-app | 2Gi → **768Mi** | ~531Mi |
| redis | 256Mi | ~6Mi |
