### PR TITLE
Upgrade cluster-autoscaler v1.26.4 -> v1.34.5

### DIFF
--- a/terraform/environments/eks/k8s-manifests-sandbox/cluster-autoscaler.yaml
+++ b/terraform/environments/eks/k8s-manifests-sandbox/cluster-autoscaler.yaml
@@ -67,7 +67,7 @@ rules:
     verbs: ["get", "list", "watch"]
   # Storage resources
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
     verbs: ["get", "list", "watch"]
   # Namespaces list is needed for TopologySpreadConstraints & PDBs
   - apiGroups: [""]
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.4
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.5
           command:
             - ./cluster-autoscaler
             - --cluster-name=ce-registry-eks

--- a/terraform/environments/eks/k8s-manifests-staging/cluster-autoscaler.yaml
+++ b/terraform/environments/eks/k8s-manifests-staging/cluster-autoscaler.yaml
@@ -67,7 +67,7 @@ rules:
     verbs: ["get", "list", "watch"]
   # Storage resources
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
     verbs: ["get", "list", "watch"]
   # Namespaces list is needed for TopologySpreadConstraints & PDBs
   - apiGroups: [""]
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: cluster-autoscaler
       containers:
         - name: cluster-autoscaler
-          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.4
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.5
           command:
             - ./cluster-autoscaler
             - --cluster-name=ce-registry-eks


### PR DESCRIPTION
## Summary

Upgrades cluster-autoscaler on `ce-registry-eks` from **v1.26.4 → v1.34.5** to match the cluster's Kubernetes **1.34** version.

## Why
CA was 8 minor versions behind the cluster. Cluster-autoscaler must track the cluster's minor version — its scheduler-simulation code is pinned per release, so a large mismatch causes subtle/broken scale decisions and is unsupported. 

## Changes
- Image: `cluster-autoscaler:v1.26.4` → **`v1.34.5`** (latest 1.34 patch).
- ClusterRole `storage.k8s.io` rule: add **`volumeattachments`** (required by v1.34; the v1.26 role lacked it). All other args/IRSA/auto-discovery unchanged.